### PR TITLE
Add a way to send events to the Ravelin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # Ravelin
 
-<<<<<<< HEAD
-The Ravelin gem is a Ruby wrapper for the
-(Ravelin API)[https://developer.ravelin.com]. Ravelin is a fraud detection
-tool. See https://ravelin.com for more information.
-=======
 [![Build Status](https://travis-ci.org/deliveroo/ravelin-ruby.svg?branch=master)](https://travis-ci.org/deliveroo/ravelin-ruby)
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ravelin`. To experiment with that code, run `bin/console` for an interactive prompt.
->>>>>>> master
+The Ravelin gem is a Ruby wrapper for the
+[Ravelin API](https://developer.ravelin.com). Ravelin is a fraud detection
+tool. See https://ravelin.com for more information.
 
 
 ## Installation
@@ -66,9 +62,9 @@ client.send_event(
 * `:chargeback`
 
 Information about the payload parameters for each event can be found in the
-(Ravelin docs)[https://developer.ravelin.com] and by checking out the
+[Ravelin docs](https://developer.ravelin.com) and by checking out the
 `Ravelin::RavelinObject` classes in the gem
-(source code)[https://github.com/deliveroo/ravelin-ruby/tree/master/lib].
+[source code](https://github.com/deliveroo/ravelin-ruby/tree/master/lib).
 
 *Note:* The payload parameter names should use underscore formatting, not
 camelcase formatting.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Ravelin
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ravelin`. To experiment with that code, run `bin/console` for an interactive prompt.
+The Ravelin gem is a Ruby wrapper for the
+(Ravelin API)[https://developer.ravelin.com]. Ravelin is a fraud detection
+tool. See https://ravelin.com for more information.
 
-TODO: Delete this and the text above, and describe your gem
 
 ## Installation
 
@@ -22,20 +23,84 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Authentication
+
+First think to do is create a client with your Ravelin API key.
+
+```ruby
+client = Ravelin::Client.new(api_key: 'sk_test_XXX')
+```
+
+
+### Send an event
+
+Events require an event `name` and `payload` as arguments. There is also an
+optional `timestamp` argument if your event occurred at a different time.
+
+```ruby
+client.send_event(
+  name: :customer,
+  timestamp: Time.now,
+  payload: {
+    # ...
+  }
+)
+```
+
+#### Event names
+
+* `:customer`
+* `:order`
+* `:items`
+* `:payment_method`
+* `:pre_transaction`
+* `:transaction`
+* `:login`
+* `:checkout`
+* `:chargeback`
+
+Information about the payload parameters for each event can be found in the
+(Ravelin docs)[https://developer.ravelin.com] and by checking out the
+`Ravelin::RavelinObject` classes in the gem
+(source code)[https://github.com/deliveroo/ravelin-ruby/tree/master/lib].
+
+*Note:* The payload parameter names should use underscore formatting, not
+camelcase formatting.
+
+
+### Send a backfill event
+
+Backfill events are designed to be used to populate Ravelin with historical
+data. The Ravelin backfill event API is identical to the regular event API,
+other than that the backfill event API is not subject to the standard rate
+limits.
+
+See https://developer.ravelin.com/#backfill for more information.
+
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and tags, and push the `.gem` file to
+[rubygems.org](https://rubygems.org).
+
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/ravelin. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/deliveroo/ravelin. This project is intended to be a safe,
+welcoming space for collaboration, and contributors are expected to adhere to
+the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](http://opensource.org/licenses/MIT).
 

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -1,5 +1,24 @@
-require "ravelin/version"
+require 'json'
+require 'faraday'
+require 'faraday_middleware'
+
+require 'ravelin/version'
+
+require 'ravelin/errors/invalid_parameters_error'
+require 'ravelin/errors/api_error'
+require 'ravelin/errors/invalid_request_error'
+require 'ravelin/errors/authentication_error'
+require 'ravelin/errors/rate_limit_error'
+
+require 'ravelin/ravelin_object'
+require 'ravelin/customer'
+require 'ravelin/event'
+require 'ravelin/client'
 
 module Ravelin
-  # Your code goes here...
+  @faraday_adapter = Faraday.default_adapter
+
+  class << self
+    attr_accessor :faraday_adapter
+  end
 end

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -1,17 +1,25 @@
+require 'date'
 require 'json'
 require 'faraday'
 require 'faraday_middleware'
 
 require 'ravelin/version'
 
-require 'ravelin/errors/invalid_parameters_error'
 require 'ravelin/errors/api_error'
 require 'ravelin/errors/invalid_request_error'
 require 'ravelin/errors/authentication_error'
 require 'ravelin/errors/rate_limit_error'
 
 require 'ravelin/ravelin_object'
+require 'ravelin/chargeback'
 require 'ravelin/customer'
+require 'ravelin/device'
+require 'ravelin/item'
+require 'ravelin/location'
+require 'ravelin/order'
+require 'ravelin/payment_method'
+require 'ravelin/transaction'
+
 require 'ravelin/event'
 require 'ravelin/client'
 
@@ -20,5 +28,9 @@ module Ravelin
 
   class << self
     attr_accessor :faraday_adapter
+
+    def camelize(str)
+      str.to_s.gsub(/_(.)/) { |e| $1.upcase }
+    end
   end
 end

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -18,6 +18,7 @@ require 'ravelin/item'
 require 'ravelin/location'
 require 'ravelin/order'
 require 'ravelin/payment_method'
+require 'ravelin/pre_transaction'
 require 'ravelin/transaction'
 
 require 'ravelin/event'

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -21,13 +21,15 @@ require 'ravelin/payment_method'
 require 'ravelin/transaction'
 
 require 'ravelin/event'
+require 'ravelin/response'
 require 'ravelin/client'
 
 module Ravelin
   @faraday_adapter = Faraday.default_adapter
+  @faraday_timeout = 1
 
   class << self
-    attr_accessor :faraday_adapter
+    attr_accessor :faraday_adapter, :faraday_timeout
 
     def camelize(str)
       str.to_s.gsub(/_(.)/) { |e| $1.upcase }

--- a/lib/ravelin/chargeback.rb
+++ b/lib/ravelin/chargeback.rb
@@ -1,0 +1,15 @@
+module Ravelin
+  class Chargeback < RavelinObject
+    attr_accessor :chargeback_id,
+      :gateway,
+      :gateway_reference,
+      :reason,
+      :status,
+      :amount,
+      :currency,
+      :dispute_time,
+      :custom
+
+    attr_required :chargeback_id, :gateway, :gateway_reference
+  end
+end

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -17,6 +17,16 @@ module Ravelin
       post("/v2/#{event.name}", event.serializable_hash)
     end
 
+    def send_backfill_event(**args)
+      unless args.has_key?(:timestamp)
+        raise ArgumentError.new('missing parameters: timestamp')
+      end
+
+      event = Event.new(**args)
+
+      post("/v2/backfill/#{event.name}", event.serializable_hash)
+    end
+
     private
 
     def post(url, payload)

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -5,7 +5,7 @@ module Ravelin
     def initialize(api_key:)
       @api_key = api_key
 
-      @connection = Faraday.new(API_BASE, { headers: headers }) do |conn|
+      @connection = Faraday.new(API_BASE, faraday_options) do |conn|
         conn.response :json, context_type: /\bjson$/
         conn.adapter Ravelin.faraday_adapter
       end
@@ -23,8 +23,7 @@ module Ravelin
       response = @connection.post(url, payload.to_json)
 
       if response.success?
-        # TODO - create and return Ravelin::Response object
-        return response
+        return Response.new(response)
       else
         handle_error_response(response)
       end
@@ -43,9 +42,15 @@ module Ravelin
       end
     end
 
-    def headers
-      { 'Authorization' => "token #{@api_key}",
-        'Content-Type'  => 'application/json; charset=utf-8' }
+    def faraday_options
+      {
+        request: { timeout: Ravelin.faraday_timeout },
+        headers: {
+          'Authorization' => "token #{@api_key}",
+          'Content-Type'  => 'application/json; charset=utf-8',
+          'User-Agent'    => "Ravelin RubyGem/#{Ravelin::VERSION}"
+        }
+      }
     end
   end
 end

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -11,10 +11,10 @@ module Ravelin
       end
     end
 
-    def send_event(event_name, event_payload)
-      event = Event.new(name: event_name, payload: event_payload)
+    def send_event(**args)
+      event = Event.new(**args)
 
-      post("/v2/#{event.name}", event.to_hash)
+      post("/v2/#{event.name}", event.serialize)
     end
 
     private

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -1,0 +1,51 @@
+module Ravelin
+  class Client
+    API_BASE = 'https://api.ravelin.com'
+
+    def initialize(api_key:)
+      @api_key = api_key
+
+      @connection = Faraday.new(API_BASE, { headers: headers }) do |conn|
+        conn.response :json, context_type: /\bjson$/
+        conn.adapter Ravelin.faraday_adapter
+      end
+    end
+
+    def send_event(event_name, event_payload)
+      event = Event.new(name: event_name, payload: event_payload)
+
+      post("/v2/#{event.name}", event.to_hash)
+    end
+
+    private
+
+    def post(url, payload)
+      response = @connection.post(url, payload.to_json)
+
+      if response.success?
+        # TODO - create and return Ravelin::Response object
+        return response
+      else
+        handle_error_response(response)
+      end
+    end
+
+    def handle_error_response(response)
+      case response.status
+      when 400, 403, 404, 405, 406
+        raise InvalidRequestError.new(response)
+      when 401
+        raise AuthenticationError.new(response)
+      when 429
+        raise RateLimitError.new(response)
+      else
+        raise ApiError.new(response)
+      end
+    end
+
+    def headers
+      { 'Authorization' => "token #{@api_key}",
+        'Content-Type'  => 'application/json; charset=utf-8' }
+    end
+  end
+end

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -14,7 +14,7 @@ module Ravelin
     def send_event(**args)
       event = Event.new(**args)
 
-      post("/v2/#{event.name}", event.serialize)
+      post("/v2/#{event.name}", event.serializable_hash)
     end
 
     private

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -57,8 +57,8 @@ module Ravelin
         request: { timeout: Ravelin.faraday_timeout },
         headers: {
           'Authorization' => "token #{@api_key}",
-          'Content-Type'  => 'application/json; charset=utf-8',
-          'User-Agent'    => "Ravelin RubyGem/#{Ravelin::VERSION}"
+          'Content-Type'  => 'application/json; charset=utf-8'.freeze,
+          'User-Agent'    => "Ravelin RubyGem/#{Ravelin::VERSION}".freeze
         }
       }
     end

--- a/lib/ravelin/customer.rb
+++ b/lib/ravelin/customer.rb
@@ -1,0 +1,6 @@
+module Ravelin
+  class Customer < RavelinObject
+    attr_accessor :customer_id, :email
+    required_attributes :customer_id
+  end
+end

--- a/lib/ravelin/customer.rb
+++ b/lib/ravelin/customer.rb
@@ -1,6 +1,26 @@
 module Ravelin
   class Customer < RavelinObject
-    attr_accessor :customer_id, :email
-    required_attributes :customer_id
+    attr_accessor :customer_id,
+      :registration_time,
+      :name,
+      :given_name,
+      :family_name,
+      :date_of_birth,
+      :gender,
+      :email,
+      :email_verified_time,
+      :user_name,
+      :telephone,
+      :telephone_verified_time,
+      :telephone_country,
+      :location,
+      :country,
+      :custom
+
+    attr_required :customer_id
+
+    def location=(obj)
+      @location = Ravelin::Location.new(obj)
+    end
   end
 end

--- a/lib/ravelin/device.rb
+++ b/lib/ravelin/device.rb
@@ -1,0 +1,14 @@
+module Ravelin
+  class Device < RavelinObject
+    attr_accessor :device_id,
+      :type,
+      :manufacturer,
+      :model,
+      :os,
+      :ip_address,
+      :browser,
+      :javascript_enabled,
+      :cookies_enabled,
+      :screen_resolution
+  end
+end

--- a/lib/ravelin/errors/api_error.rb
+++ b/lib/ravelin/errors/api_error.rb
@@ -1,0 +1,19 @@
+module Ravelin
+  class ApiError < StandardError
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    def to_s
+      parts = [
+        @response.status,
+        @response.body.fetch('message', nil),
+        @response.body.fetch('validationErrors', []).join('; ')
+      ]
+
+      parts.compact.join(' - ')
+    end
+  end
+end

--- a/lib/ravelin/errors/api_error.rb
+++ b/lib/ravelin/errors/api_error.rb
@@ -1,18 +1,17 @@
 module Ravelin
   class ApiError < StandardError
-    attr_reader :response
+    attr_reader :response, :status, :message, :validation_errors
 
     def initialize(response)
-      @response = response
+      @response           = response
+      @status             = response.status
+      @message            = response.body.fetch('message', nil)
+      @validation_errors  = response.body.fetch('validationErrors', [])
     end
 
     def to_s
-      parts = [
-        @response.status,
-        @response.body.fetch('message', nil),
-        @response.body.fetch('validationErrors', []).join('; ')
-      ]
-
+      parts = [self.status, self.message]
+      parts << self.validation_errors.join('; ') if self.validation_errors.any?
       parts.compact.join(' - ')
     end
   end

--- a/lib/ravelin/errors/api_error.rb
+++ b/lib/ravelin/errors/api_error.rb
@@ -1,16 +1,17 @@
 module Ravelin
   class ApiError < StandardError
-    attr_reader :response, :status, :message, :validation_errors
+    attr_reader :response, :status, :error, :error_message, :validation_errors
 
     def initialize(response)
       @response           = response
       @status             = response.status
-      @message            = response.body.fetch('message', nil)
+      @error              = response.body.fetch('Error', nil)
+      @error_message      = response.body.fetch('message', nil)
       @validation_errors  = response.body.fetch('validationErrors', [])
     end
 
     def to_s
-      parts = [self.status, self.message]
+      parts = [self.status, self.error, self.error_message]
       parts << self.validation_errors.join('; ') if self.validation_errors.any?
       parts.compact.join(' - ')
     end

--- a/lib/ravelin/errors/authentication_error.rb
+++ b/lib/ravelin/errors/authentication_error.rb
@@ -1,0 +1,4 @@
+module Ravelin
+  class AuthenticationError < ApiError
+  end
+end

--- a/lib/ravelin/errors/invalid_parameters_error.rb
+++ b/lib/ravelin/errors/invalid_parameters_error.rb
@@ -1,0 +1,4 @@
+module Ravelin
+  class InvalidParametersError < StandardError
+  end
+end

--- a/lib/ravelin/errors/invalid_parameters_error.rb
+++ b/lib/ravelin/errors/invalid_parameters_error.rb
@@ -1,4 +1,0 @@
-module Ravelin
-  class InvalidParametersError < StandardError
-  end
-end

--- a/lib/ravelin/errors/invalid_request_error.rb
+++ b/lib/ravelin/errors/invalid_request_error.rb
@@ -1,0 +1,4 @@
+module Ravelin
+  class InvalidRequestError < ApiError
+  end
+end

--- a/lib/ravelin/errors/rate_limit_error.rb
+++ b/lib/ravelin/errors/rate_limit_error.rb
@@ -1,0 +1,4 @@
+module Ravelin
+  class RateLimitError < ApiError
+  end
+end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -16,20 +16,12 @@ module Ravelin
 
         if v.is_a?(Ravelin::RavelinObject)
           [k, v.serializable_hash]
-        elsif v.is_a?(Array)
-          [k, v.map(&:serializable_hash)]
         else
           [k, v]
         end
       end
 
-      return payload_hash.merge('timestamp' => timestamp)
-    end
-
-    def list_object_classes
-      {
-        items: Item
-      }
+      payload_hash.merge('timestamp' => timestamp)
     end
 
     def object_classes
@@ -37,7 +29,6 @@ module Ravelin
         chargeback:     Chargeback,
         customer:       Customer,
         device:         Device,
-        item:           Item,
         location:       Location,
         order:          Order,
         payment_method: PaymentMethod,
@@ -54,8 +45,6 @@ module Ravelin
       case self.name
         when :customer
           validate_payload_inclusion_of :customer
-        when :items
-          validate_payload_inclusion_of :order_id
         when :pretransaction, :transaction
           validate_payload_inclusion_of :order_id, :payment_method_id
         when :login
@@ -118,7 +107,7 @@ module Ravelin
         pre_transaction: :pretransaction
       }
 
-      return underscore_mapping.fetch(str.to_sym, str.to_sym)
+      underscore_mapping.fetch(str.to_sym, str.to_sym)
     end
 
     def hash_map(hash, &block)

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -26,13 +26,13 @@ module Ravelin
       return payload_hash.merge('timestamp' => timestamp)
     end
 
-    def self.list_object_classes
+    def list_object_classes
       {
         items: Item
       }
     end
 
-    def self.object_classes
+    def object_classes
       {
         chargeback:     Chargeback,
         customer:       Customer,
@@ -41,7 +41,7 @@ module Ravelin
         location:       Location,
         order:          Order,
         payment_method: PaymentMethod,
-        transaction:    Transaction
+        transaction:    self.name == :transaction ? Transaction : PreTransaction
       }
     end
 
@@ -89,7 +89,7 @@ module Ravelin
     def convert_to_epoch(time)
       if time.is_a?(Time)
         time.to_i
-      elsif time.is_a?(DateTime) && time.responds_to?(:to_i)
+      elsif time.is_a?(DateTime) && time.respond_to?(:to_i)
         time.to_i
       elsif time.is_a?(Integer)
         time
@@ -102,9 +102,9 @@ module Ravelin
       hash_map(payload) do |k, v|
         k = k.to_sym
 
-        if v.is_a?(Array) && klass = self.class.list_object_classes[k]
+        if v.is_a?(Array) && klass = list_object_classes[k]
           [k, v.map { |item| klass.new(item) }]
-        elsif v.is_a?(Hash) && klass = self.class.object_classes[k]
+        elsif v.is_a?(Hash) && klass = object_classes[k]
           [k, klass.new(v)]
         else
           [k, v]

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -91,9 +91,7 @@ module Ravelin
       hash_map(payload) do |k, v|
         k = k.to_sym
 
-        if v.is_a?(Array) && klass = list_object_classes[k]
-          [k, v.map { |item| klass.new(item) }]
-        elsif v.is_a?(Hash) && klass = object_classes[k]
+        if v.is_a?(Hash) && klass = object_classes[k]
           [k, klass.new(v)]
         else
           [k, v]

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -52,6 +52,8 @@ module Ravelin
         :pretransaction, :transaction
 
       case self.name
+        when :customer
+          validate_payload_inclusion_of :customer
         when :items
           validate_payload_inclusion_of :order_id
         when :pretransaction, :transaction
@@ -66,7 +68,8 @@ module Ravelin
 
     def validate_customer_presence_on(*events)
       if events.include?(self.name) && !payload_customer_reference_present?
-        argument_error(%q{payload missing customer_id or temp_customer_id parameter})
+        raise ArgumentError.
+          new(%q{payload missing customer_id or temp_customer_id parameter})
       end
     end
 
@@ -74,16 +77,13 @@ module Ravelin
       missing = required_keys - self.payload.keys
 
       if missing.any?
-        argument_error(%Q{payload missing parameters: #{missing.join(', ')}})
+        raise ArgumentError.
+          new(%Q{payload missing parameters: #{missing.join(', ')}})
       end
     end
 
     def payload_customer_reference_present?
       self.payload.keys.any? {|k| %i(customer_id temp_customer_id).include? k }
-    end
-
-    def argument_error(msg)
-      raise ArgumentError.new(msg)
     end
 
     def convert_to_epoch(time)

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -1,31 +1,111 @@
 module Ravelin
   class Event
-    attr_accessor :name, :payload
+    attr_accessor :name, :timestamp, :payload
 
-    def initialize(name:, payload:)
-      @name = name
+    def initialize(name:, payload:, timestamp: nil)
+      @name = name.to_sym
       @payload = convert_to_ravelin_objects(payload)
+      @timestamp = timestamp.nil? ? Time.now.to_i : convert_to_epoch(timestamp)
+
+      validate_top_level_payload_params
     end
 
-    def to_hash
-      hash_map(self.payload) do |k, v|
-        v.is_a?(Ravelin::RavelinObject) ? [k, v.to_hash] : [k, v]
+    def serialize
+      payload_hash = hash_map(self.payload) do |k, v|
+        k = Ravelin.camelize(k)
+
+        if v.is_a?(Ravelin::RavelinObject)
+          [k, v.serialize]
+        elsif v.is_a?(Array)
+          [k, v.map(&:serialize)]
+        else
+          [k, v]
+        end
       end
+
+      return payload_hash.merge('timestamp' => timestamp)
+    end
+
+    def self.list_object_classes
+      {
+        items: Item
+      }
     end
 
     def self.object_classes
-      # TODO - Add all the API event classes
       {
-        customer: Customer
+        chargeback:     Chargeback,
+        customer:       Customer,
+        device:         Device,
+        item:           Item,
+        location:       Location,
+        order:          Order,
+        payment_method: PaymentMethod,
+        transaction:    Transaction
       }
     end
 
     private
 
+    def validate_top_level_payload_params
+      validate_customer_presence_on :order, :items, :paymentmethod,
+        :pretransaction, :transaction
+
+      case self.name
+        when :items
+          validate_payload_inclusion_of :order_id
+        when :pretransaction, :transaction
+          validate_payload_inclusion_of :order_id, :payment_method_id
+        when :login
+          validate_payload_inclusion_of :customer_id, :temp_customer_id
+        when :checkout
+          validate_payload_inclusion_of :customer, :order, :items,
+            :payment_method, :transaction
+      end
+    end
+
+    def validate_customer_presence_on(*events)
+      if events.include?(self.name) && !payload_customer_reference_present?
+        argument_error(%q{payload missing customer_id or temp_customer_id parameter})
+      end
+    end
+
+    def validate_payload_inclusion_of(*required_keys)
+      missing = required_keys - self.payload.keys
+
+      if missing.any?
+        argument_error(%Q{payload missing parameters: #{missing.join(', ')}})
+      end
+    end
+
+    def payload_customer_reference_present?
+      self.payload.keys.any? {|k| %i(customer_id temp_customer_id).include? k }
+    end
+
+    def argument_error(msg)
+      raise ArgumentError.new(msg)
+    end
+
+    def convert_to_epoch(time)
+      if time.is_a?(Time)
+        time.to_i
+      elsif time.is_a?(DateTime) && time.responds_to?(:to_i)
+        time.to_i
+      elsif time.is_a?(Integer)
+        time
+      else
+        raise TypeError.new(%Q{timestamp requires a Time or epoch Integer})
+      end
+    end
+
     def convert_to_ravelin_objects(payload)
-      hash_map(payload) do |k,v|
-        if v.is_a?(Hash) && self.class.object_classes.has_key?(k)
-          [k, self.class.object_classes[k].new(v)]
+      hash_map(payload) do |k, v|
+        k = k.to_sym
+
+        if v.is_a?(Array) && klass = self.class.list_object_classes[k]
+          [k, v.map { |item| klass.new(item) }]
+        elsif v.is_a?(Hash) && klass = self.class.object_classes[k]
+          [k, klass.new(v)]
         else
           [k, v]
         end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -3,7 +3,7 @@ module Ravelin
     attr_accessor :name, :timestamp, :payload
 
     def initialize(name:, payload:, timestamp: nil)
-      @name = name.to_sym
+      @name = convert_event_name(name)
       @payload = convert_to_ravelin_objects(payload)
       @timestamp = timestamp.nil? ? Time.now.to_i : convert_to_epoch(timestamp)
 
@@ -110,6 +110,15 @@ module Ravelin
           [k, v]
         end
       end
+    end
+
+    def convert_event_name(str)
+      underscore_mapping = {
+        payment_method: :paymentmethod,
+        pre_transaction: :pretransaction
+      }
+
+      return underscore_mapping.fetch(str.to_sym, str.to_sym)
     end
 
     def hash_map(hash, &block)

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -10,14 +10,14 @@ module Ravelin
       validate_top_level_payload_params
     end
 
-    def serialize
+    def serializable_hash
       payload_hash = hash_map(self.payload) do |k, v|
         k = Ravelin.camelize(k)
 
         if v.is_a?(Ravelin::RavelinObject)
-          [k, v.serialize]
+          [k, v.serializable_hash]
         elsif v.is_a?(Array)
-          [k, v.map(&:serialize)]
+          [k, v.map(&:serializable_hash)]
         else
           [k, v]
         end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -1,0 +1,39 @@
+module Ravelin
+  class Event
+    attr_accessor :name, :payload
+
+    def initialize(name:, payload:)
+      @name = name
+      @payload = convert_to_ravelin_objects(payload)
+    end
+
+    def to_hash
+      hash_map(self.payload) do |k, v|
+        v.is_a?(Ravelin::RavelinObject) ? [k, v.to_hash] : [k, v]
+      end
+    end
+
+    def self.object_classes
+      # TODO - Add all the API event classes
+      {
+        customer: Customer
+      }
+    end
+
+    private
+
+    def convert_to_ravelin_objects(payload)
+      hash_map(payload) do |k,v|
+        if v.is_a?(Hash) && self.class.object_classes.has_key?(k)
+          [k, self.class.object_classes[k].new(v)]
+        else
+          [k, v]
+        end
+      end
+    end
+
+    def hash_map(hash, &block)
+      Hash[hash.map { |k, v| block.call(k, v) }]
+    end
+  end
+end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -41,7 +41,7 @@ module Ravelin
         location:       Location,
         order:          Order,
         payment_method: PaymentMethod,
-        transaction:    self.name == :transaction ? Transaction : PreTransaction
+        transaction:    self.name == :pretransaction ? PreTransaction : Transaction
       }
     end
 

--- a/lib/ravelin/item.rb
+++ b/lib/ravelin/item.rb
@@ -1,0 +1,15 @@
+module Ravelin
+  class Item < RavelinObject
+    attr_accessor :sku,
+      :name,
+      :price,
+      :currency,
+      :brand,
+      :upc,
+      :category,
+      :quantity,
+      :custom
+
+    attr_required :sku, :quantity
+  end
+end

--- a/lib/ravelin/location.rb
+++ b/lib/ravelin/location.rb
@@ -1,0 +1,12 @@
+module Ravelin
+  class Location < RavelinObject
+    attr_accessor :location_id,
+      :street1,
+      :street2,
+      :locality,
+      :postal_code,
+      :country,
+      :latitude,
+      :longitude
+  end
+end

--- a/lib/ravelin/location.rb
+++ b/lib/ravelin/location.rb
@@ -3,10 +3,16 @@ module Ravelin
     attr_accessor :location_id,
       :street1,
       :street2,
-      :locality,
-      :postal_code,
+      :neighbourhood,
+      :zone,
+      :city,
+      :region,
       :country,
+      :po_box_number,
+      :postal_code,
       :latitude,
-      :longitude
+      :longitude,
+      :geohash,
+      :custom
   end
 end

--- a/lib/ravelin/order.rb
+++ b/lib/ravelin/order.rb
@@ -1,0 +1,24 @@
+module Ravelin
+  class Order < RavelinObject
+    attr_accessor :order_id,
+      :email,
+      :price,
+      :currency,
+      :seller_id,
+      :from,
+      :to,
+      :country,
+      :market,
+      :custom
+
+    attr_required :order_id, :price
+
+    def from=(obj)
+      @from = Ravelin::Location.new(obj)
+    end
+
+    def to=(obj)
+      @to = Ravelin::Location.new(obj)
+    end
+  end
+end

--- a/lib/ravelin/order.rb
+++ b/lib/ravelin/order.rb
@@ -15,7 +15,7 @@ module Ravelin
     attr_required :order_id
 
     def items=(arr)
-      #raise ArgumentError.new('items= requires an Array') unless arr.is_a?(Array)
+      raise ArgumentError.new('items= requires an Array') unless arr.is_a?(Array)
 
       @items = arr.map { |item| Ravelin::Item.new(item) }
     end

--- a/lib/ravelin/order.rb
+++ b/lib/ravelin/order.rb
@@ -5,6 +5,7 @@ module Ravelin
       :price,
       :currency,
       :seller_id,
+      :items,
       :from,
       :to,
       :country,
@@ -12,6 +13,12 @@ module Ravelin
       :custom
 
     attr_required :order_id
+
+    def items=(arr)
+      #raise ArgumentError.new('items= requires an Array') unless arr.is_a?(Array)
+
+      @items = arr.map { |item| Ravelin::Item.new(item) }
+    end
 
     def from=(obj)
       @from = Ravelin::Location.new(obj)

--- a/lib/ravelin/order.rb
+++ b/lib/ravelin/order.rb
@@ -11,7 +11,7 @@ module Ravelin
       :market,
       :custom
 
-    attr_required :order_id, :price
+    attr_required :order_id
 
     def from=(obj)
       @from = Ravelin::Location.new(obj)

--- a/lib/ravelin/payment_method.rb
+++ b/lib/ravelin/payment_method.rb
@@ -1,0 +1,13 @@
+module Ravelin
+  class PaymentMethod < RavelinObject
+    attr_accessor :payment_method_id,
+      :nick_name,
+      :method_type,
+      :banned,
+      :active,
+      :registration_time,
+      :custom
+
+    attr_required :payment_method_id, :method_type
+  end
+end

--- a/lib/ravelin/pre_transaction.rb
+++ b/lib/ravelin/pre_transaction.rb
@@ -1,0 +1,13 @@
+module Ravelin
+  class PreTransaction < RavelinObject
+    attr_accessor :transaction_id,
+      :email,
+      :currency,
+      :debit,
+      :credit,
+      :gateway,
+      :custom
+
+    attr_required :transaction_id, :currency, :debit, :credit, :gateway
+  end
+end

--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -36,13 +36,13 @@ module Ravelin
       end
     end
 
-    def serialize
+    def serializable_hash
       self.class.attributes.each_with_object({}) do |key, hash|
         value = self.send(key)
         key = Ravelin.camelize(key)
 
         if value.is_a?(RavelinObject)
-          hash[key] = value.serialize
+          hash[key] = value.serializable_hash
         elsif !value.nil?
           hash[key] = value
         end

--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -41,6 +41,8 @@ module Ravelin
 
         if value.is_a?(RavelinObject)
           hash[key] = value.serializable_hash
+        elsif value.is_a?(Array)
+          hash[key] = value.map(&:serializable_hash)
         elsif !value.nil?
           hash[key] = value
         end

--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -19,9 +19,7 @@ module Ravelin
     end
 
     def initialize(**args)
-      args.each do |key, value|
-        self.send("#{key}=", value)
-      end
+      args.each { |key, value| self.send("#{key}=", value) }
 
       validate
     end

--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -1,0 +1,53 @@
+module Ravelin
+  class RavelinObject
+    class << self
+      attr_reader :attributes
+
+      def ravelin_required_attributes
+        @ravelin_required_attributes ||= []
+      end
+
+      def required_attributes(*names)
+        @ravelin_required_attributes = *names
+      end
+
+      def attr_accessor(*names)
+        @attributes ||= []
+        @attributes.concat(names)
+        super
+      end
+    end
+
+    def initialize(**args)
+      args.each do |key, value|
+        self.send("#{key}=", value)
+      end
+
+      validate
+    end
+
+    def validate
+      invalid_attrs = self.class.ravelin_required_attributes.select do |name|
+        self.send(name).nil? || self.send(name) == ''
+      end
+
+      errors = invalid_attrs.map do |a|
+        %Q{"#{a}" can't be blank for #{self.class.name}}
+      end
+
+      raise InvalidParametersError.new(errors.join(', ')) if errors.any?
+    end
+
+    def to_hash
+      self.class.attributes.each_with_object({}) do |key, hash|
+        hash[camelize(key)] = self.send(key) unless self.send(key).nil?
+      end
+    end
+
+    private
+
+    def camelize(str)
+      str.to_s.gsub(/_(.)/) { |e| $1.upcase }
+    end
+  end
+end

--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -1,7 +1,7 @@
 module Ravelin
   class RavelinObject
     class << self
-      attr_reader :attributes
+      attr_reader :attr_accessor_names
 
       def required_attributes
         @required_attributes ||= []
@@ -12,8 +12,8 @@ module Ravelin
       end
 
       def attr_accessor(*names)
-        @attributes ||= []
-        @attributes.concat(names)
+        @attr_accessor_names ||= []
+        @attr_accessor_names.concat(names)
         super
       end
     end
@@ -35,7 +35,7 @@ module Ravelin
     end
 
     def serializable_hash
-      self.class.attributes.each_with_object({}) do |key, hash|
+      self.class.attr_accessor_names.each_with_object({}) do |key, hash|
         value = self.send(key)
         key = Ravelin.camelize(key)
 

--- a/lib/ravelin/response.rb
+++ b/lib/ravelin/response.rb
@@ -1,0 +1,26 @@
+module Ravelin
+  class Response
+    attr_reader :customer_id,
+      :action,
+      :score,
+      :score_id,
+      :source,
+      :comment,
+      :http_status,
+      :http_body
+
+    def initialize(faraday_response)
+      data = faraday_response.body.fetch('data', {})
+
+      @customer_id  = data['customerId']
+      @action       = data['action']
+      @score        = data['score']
+      @score_id     = data['scoreId']
+      @source       = data['source']
+      @comment      = data['comment']
+      @customer_id  = data['customerId']
+      @http_status  = faraday_response.status
+      @http_body    = faraday_response.body
+    end
+  end
+end

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -1,19 +1,25 @@
 module Ravelin
   class Transaction < RavelinObject
     attr_accessor :transaction_id,
-      :success,
       :email,
       :currency,
       :debit,
       :credit,
+      :gateway,
+      :custom,
+      :success,
       :auth_code,
       :decline_code,
-      :gateway,
       :gateway_reference,
       :avs_result_code,
-      :cvv_result_code,
-      :custom
+      :cvv_result_code
 
-    attr_required :transaction_id, :currency, :debit, :credit, :gateway
+    attr_required :transaction_id,
+      :currency,
+      :debit,
+      :credit,
+      :gateway,
+      :gateway_reference,
+      :success
   end
 end

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -1,0 +1,19 @@
+module Ravelin
+  class Transaction < RavelinObject
+    attr_accessor :transaction_id,
+      :success,
+      :email,
+      :currency,
+      :debit,
+      :credit,
+      :auth_code,
+      :decline_code,
+      :gateway,
+      :gateway_reference,
+      :avs_result_code,
+      :cvv_result_code,
+      :custom
+
+    attr_required :transaction_id, :currency, :debit, :credit, :gateway
+  end
+end

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir['lib/**/*.rb']
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -43,13 +43,19 @@ describe Ravelin::Client do
     let(:client) { described_class.new(api_key: 'abc') }
     let(:event) { double('event', name: 'ping', serialize: { name: 'value' }) }
 
-    before { allow(Ravelin::Event).to receive(:new).and_return(event) }
+    before do
+      allow(Ravelin::Event).to receive(:new).and_return(event)
+      #allow(Ravelin::Response).to receive(:new)
+    end
 
     it 'calls Ravelin with correct headers and body' do
       stub = stub_request(:post, 'https://api.ravelin.com/v2/ping').
         with(
           headers: { 'Authorization' => 'token abc' },
           body: { name: 'value' }.to_json
+        ).and_return(
+          headers: { 'Content-Type' => 'application/json' },
+          body: '{}'
         )
 
       client.send_event
@@ -60,14 +66,17 @@ describe Ravelin::Client do
     context 'response' do
       before do
         stub_request(:post, 'https://api.ravelin.com/v2/ping').
-          to_return(status: response_status)
+          to_return(
+            status: response_status,
+            body: '{}'
+          )
       end
 
       context 'successful' do
         let(:response_status) { 200 }
 
         it 'returns the response' do
-          expect(client.send_event).to be_a(Faraday::Response)
+          expect(client.send_event).to be_a(Ravelin::Response)
         end
 
         it "not treated as an error" do

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -11,10 +11,12 @@ describe Ravelin::Client do
   end
 
   describe '#send_event' do
+    let(:client) { described_class.new(api_key: 'abc') }
     let(:event_name) { 'foobar' }
     let(:event_payload) { { id: 'ch-123' } }
-    let(:event) { double('event', name: event_name, serialize: event_payload) }
-    let(:client) { described_class.new(api_key: 'abc') }
+    let(:event) do
+      double('event', name: event_name, serializable_hash: event_payload)
+    end
 
     before { allow(client).to receive(:post) }
 
@@ -41,7 +43,9 @@ describe Ravelin::Client do
 
   describe '#post' do
     let(:client) { described_class.new(api_key: 'abc') }
-    let(:event) { double('event', name: 'ping', serialize: { name: 'value' }) }
+    let(:event) do
+      double('event', name: 'ping', serializable_hash: { name: 'value' })
+    end
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
@@ -106,7 +110,7 @@ describe Ravelin::Client do
       end
     end
 
-    let(:event) { double('event', name: :ping, serialize: {}) }
+    let(:event) { double('event', name: :ping, serializable_hash: {}) }
     let(:client) { described_class.new(api_key: 'abc') }
 
     before do

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+
+describe Ravelin::Client do
+  describe '#initialize' do
+    it 'initializes a Faraday connection' do
+      expect(Faraday).to receive(:new).
+        with('https://api.ravelin.com', kind_of(Hash))
+
+      described_class.new(api_key: 'abc')
+    end
+  end
+
+  describe '#send_event' do
+    let(:event_name) { 'my-event' }
+    let(:event_payload) { { key: 'value' } }
+    let(:event) { double('event', name: event_name, to_hash: event_payload) }
+    let(:client) { described_class.new(api_key: 'abc') }
+
+    before { allow(client).to receive(:post) }
+
+    it 'creates an event with method arguments' do
+      expect(Ravelin::Event).to receive(:new).
+        with(name: 'my-event', payload: { key: 'value' }).
+        and_return(event)
+
+      client.send_event('my-event', event_payload)
+    end
+
+    it 'calls #post with Event payload' do
+      allow(Ravelin::Event).to receive(:new) { event }
+
+      expect(client).to receive(:post).with("/v2/my-event", { key: 'value' })
+
+      client.send_event(event_name, event_payload)
+    end
+  end
+
+  describe '#post' do
+    let(:client) { described_class.new(api_key: 'abc') }
+    let(:event) { double('event', name: 'ping', to_hash: { name: 'value' }) }
+
+    before { allow(Ravelin::Event).to receive(:new).and_return(event) }
+
+    it 'calls Ravelin with correct headers and body' do
+      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping').
+        with(
+          headers: { 'Authorization' => 'token abc' },
+          body: { name: 'value' }.to_json
+        )
+
+      client.send_event(:ping, {})
+
+      expect(stub).to have_been_requested
+    end
+
+    context 'response' do
+      before do
+        stub_request(:post, 'https://api.ravelin.com/v2/ping').
+          to_return(status: response_status)
+      end
+
+      context 'successful' do
+        let(:response_status) { 200 }
+
+        it 'returns the response' do
+          expect( client.send_event(:ping, {}) ).to be_a(Faraday::Response)
+        end
+
+        it "not treated as an error" do
+          expect(client).to_not receive(:handle_error_response)
+
+          client.send_event(:ping, {})
+        end
+      end
+
+      context 'error' do
+        let(:response_status) { 400 }
+
+        it 'handles error response' do
+          expect(client).to receive(:handle_error_response).
+            with(kind_of(Faraday::Response))
+
+          client.send_event(:ping, {})
+        end
+      end
+    end
+  end
+
+  describe '#handle_error_response' do
+    shared_examples 'raises error with' do |error_class|
+      it "raises #{error_class} error" do
+        expect { client.send_event(:ping, {}) }.to raise_exception(error_class)
+      end
+    end
+
+    let(:event) { double('event', name: :ping, to_hash: {}) }
+    let(:client) { described_class.new(api_key: 'abc') }
+
+    before do
+      allow(Ravelin::Event).to receive(:new).and_return(event)
+      stub_request(:post, 'https://api.ravelin.com/v2/ping').
+        and_return(status: status_code, body: "{}")
+    end
+
+    context 'HTTP status 400' do
+      let(:status_code) { 400 }
+      include_examples 'raises error with', Ravelin::InvalidRequestError
+    end
+
+    context 'HTTP status 403' do
+      let(:status_code) { 403 }
+      include_examples 'raises error with', Ravelin::InvalidRequestError
+    end
+
+    context 'HTTP status 404' do
+      let(:status_code) { 404 }
+      include_examples 'raises error with', Ravelin::InvalidRequestError
+    end
+
+    context 'HTTP status 405' do
+      let(:status_code) { 405 }
+      include_examples 'raises error with', Ravelin::InvalidRequestError
+    end
+
+    context 'HTTP status 406' do
+      let(:status_code) { 406 }
+      include_examples 'raises error with', Ravelin::InvalidRequestError
+    end
+
+    context 'HTTP status 401' do
+      let(:status_code) { 401 }
+      include_examples 'raises error with', Ravelin::AuthenticationError
+    end
+
+    context 'HTTP status 429' do
+      let(:status_code) { 429 }
+      include_examples 'raises error with', Ravelin::RateLimitError
+    end
+
+    context 'HTTP status 500' do
+      let(:status_code) { 500 }
+      include_examples 'raises error with', Ravelin::ApiError
+    end
+  end
+end

--- a/spec/ravelin/customer_spec.rb
+++ b/spec/ravelin/customer_spec.rb
@@ -7,8 +7,8 @@ describe Ravelin::Customer do
 
   it 'raises exception when missing required params' do
     expect { described_class.new }.to raise_exception(
-      Ravelin::InvalidParametersError,
-      %q{"customer_id" can't be blank for Ravelin::Customer}
+      ArgumentError,
+      'missing parameters: customer_id'
     )
   end
 end

--- a/spec/ravelin/customer_spec.rb
+++ b/spec/ravelin/customer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Ravelin::Customer do
+  it 'creates instance with valid params' do
+    expect { described_class.new(customer_id: 'abc') }.to_not raise_exception
+  end
+
+  it 'raises exception when missing required params' do
+    expect { described_class.new }.to raise_exception(
+      Ravelin::InvalidParametersError,
+      %q{"customer_id" can't be blank for Ravelin::Customer}
+    )
+  end
+end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -9,7 +9,7 @@ describe Ravelin::Event do
     described_class.new(name: :ping, timestamp: 12345, payload: {})
   end
 
-  describe '#serialize' do
+  describe '#serializable_hash' do
     let(:dummy) { MyDummyClass.new(name: 'Fraudster') }
 
     before { allow(event).to receive(:payload).and_return(payload) }
@@ -18,15 +18,15 @@ describe Ravelin::Event do
       let(:payload) { { name: 'John' } }
 
       it 'left as they are' do
-        expect(event.serialize).to eq({ 'name' => 'John', 'timestamp' => 12345 })
+        expect(event.serializable_hash).to eq({ 'name' => 'John', 'timestamp' => 12345 })
       end
     end
 
     context 'payload with Ravelin objects' do
       let(:payload) { { dummy: dummy } }
 
-      it 'converts the Ravelin objects to hashes' do
-        expect(event.serialize).to eq({
+      it 'converts the Ravelin objects to hash with camelcase keys' do
+        expect(event.serializable_hash).to eq({
           'timestamp' => 12345,
           'dummy' => { 'name' => 'Fraudster' }
         })
@@ -36,8 +36,8 @@ describe Ravelin::Event do
     context 'payload with lists of Ravelin objects' do
       let(:payload) { { things: [dummy, dummy] } }
 
-      it 'converts the list of Ravelin objects to hashes' do
-        expect(event.serialize).to eq({
+      it 'converts the list of Ravelin objects to hashes with camelcase keys' do
+        expect(event.serializable_hash).to eq({
           'timestamp' => 12345,
           'things' => [
             { 'name' => 'Fraudster' },

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -35,20 +35,6 @@ describe Ravelin::Event do
         })
       end
     end
-
-    context 'payload with lists of Ravelin objects' do
-      let(:payload) { { things: [dummy, dummy] } }
-
-      it 'converts the list of Ravelin objects to hashes with camelcase keys' do
-        expect(event.serializable_hash).to eq({
-          'timestamp' => 12345,
-          'things' => [
-            { 'name' => 'Fraudster' },
-            { 'name' => 'Fraudster' }
-          ]
-        })
-      end
-    end
   end
 
   describe '#validate_top_level_payload_params' do
@@ -159,25 +145,13 @@ describe Ravelin::Event do
     before do
       allow_any_instance_of(Ravelin::Event).to receive(:object_classes).
         and_return({ dummy: MyDummyClass })
-      allow_any_instance_of(Ravelin::Event).to receive(:list_object_classes).
-        and_return({ things: MyDummyClass })
     end
 
-    context 'when key found in .object_classes' do
+    context 'when key found in #object_classes' do
       let(:payload) { { dummy: { name: 'Fraudster' } } }
 
       it 'converts payload values to Ravelin objects' do
         expect(event.payload).to include({ dummy: instance_of(MyDummyClass) })
-      end
-    end
-
-    context 'when key found in .list_object_classes' do
-      let(:payload) { { things: [ { name: 'dummy-1' }, { name: 'dummy-2' }] } }
-
-      it 'converts payload list values to Ravelin objects' do
-        expect(event.payload).to include({
-          things: [instance_of(MyDummyClass), instance_of(MyDummyClass)]
-        })
       end
     end
 

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -5,46 +5,90 @@ class MyDummyClass < Ravelin::RavelinObject
 end
 
 describe Ravelin::Event do
-  let(:event) { described_class.new(name: :ping, payload: {}) }
+  let(:event) do
+    described_class.new(name: :ping, timestamp: 12345, payload: {})
+  end
 
-  describe '#to_hash' do
+  describe '#serialize' do
     let(:dummy) { MyDummyClass.new(name: 'Fraudster') }
 
     before { allow(event).to receive(:payload).and_return(payload) }
 
     context 'payload with non Ravelin objects' do
-      let(:payload) { { name: 'John', timestamp: 123456789 } }
+      let(:payload) { { name: 'John' } }
 
       it 'left as they are' do
-        expect(event.to_hash).to eq({ name: 'John', timestamp: 123456789 })
+        expect(event.serialize).to eq({ 'name' => 'John', 'timestamp' => 12345 })
       end
     end
 
-    context 'payload with mixed objects' do
-      let(:payload) { { timestamp: 12345, dummy: dummy } }
+    context 'payload with Ravelin objects' do
+      let(:payload) { { dummy: dummy } }
 
-      it 'converts the Ravelin objects to hash' do
-        expect(event.to_hash).to eq({
-          timestamp: 12345,
-          dummy: { 'name' => 'Fraudster' }
+      it 'converts the Ravelin objects to hashes' do
+        expect(event.serialize).to eq({
+          'timestamp' => 12345,
+          'dummy' => { 'name' => 'Fraudster' }
+        })
+      end
+    end
+
+    context 'payload with lists of Ravelin objects' do
+      let(:payload) { { things: [dummy, dummy] } }
+
+      it 'converts the list of Ravelin objects to hashes' do
+        expect(event.serialize).to eq({
+          'timestamp' => 12345,
+          'things' => [
+            { 'name' => 'Fraudster' },
+            { 'name' => 'Fraudster' }
+          ]
         })
       end
     end
   end
 
+  describe '#validate_top_level_payload_params' do
+    context 'customer presence required' do
+      pending
+    end
+
+    context 'payload parameters required' do
+      pending
+    end
+  end
+
+  describe '#convert_to_epoch' do
+    pending
+  end
+
   describe '#convert_to_ravelin_objects' do
-    let(:event) { described_class.new(name: :ping, payload: payload) }
+    let(:event) do
+      described_class.new(name: :ping, timestamp: 12345, payload: payload)
+    end
 
     before do
       allow(Ravelin::Event).to receive(:object_classes).
         and_return({ dummy: MyDummyClass })
+      allow(Ravelin::Event).to receive(:list_object_classes).
+        and_return({ things: MyDummyClass })
     end
 
-    context 'when key found in #object_classes' do
+    context 'when key found in .object_classes' do
       let(:payload) { { dummy: { name: 'Fraudster' } } }
 
       it 'converts payload values to Ravelin objects' do
         expect(event.payload).to include({ dummy: instance_of(MyDummyClass) })
+      end
+    end
+
+    context 'when key found in .list_object_classes' do
+      let(:payload) { { things: [ { name: 'dummy-1' }, { name: 'dummy-2' }] } }
+
+      it 'converts payload list values to Ravelin objects' do
+        expect(event.payload).to include({
+          things: [instance_of(MyDummyClass), instance_of(MyDummyClass)]
+        })
       end
     end
 

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+class MyDummyClass < Ravelin::RavelinObject
+  attr_accessor :name
+end
+
+describe Ravelin::Event do
+  let(:event) { described_class.new(name: :ping, payload: {}) }
+
+  describe '#to_hash' do
+    let(:dummy) { MyDummyClass.new(name: 'Fraudster') }
+
+    before { allow(event).to receive(:payload).and_return(payload) }
+
+    context 'payload with non Ravelin objects' do
+      let(:payload) { { name: 'John', timestamp: 123456789 } }
+
+      it 'left as they are' do
+        expect(event.to_hash).to eq({ name: 'John', timestamp: 123456789 })
+      end
+    end
+
+    context 'payload with mixed objects' do
+      let(:payload) { { timestamp: 12345, dummy: dummy } }
+
+      it 'converts the Ravelin objects to hash' do
+        expect(event.to_hash).to eq({
+          timestamp: 12345,
+          dummy: { 'name' => 'Fraudster' }
+        })
+      end
+    end
+  end
+
+  describe '#convert_to_ravelin_objects' do
+    let(:event) { described_class.new(name: :ping, payload: payload) }
+
+    before do
+      allow(Ravelin::Event).to receive(:object_classes).
+        and_return({ dummy: MyDummyClass })
+    end
+
+    context 'when key found in #object_classes' do
+      let(:payload) { { dummy: { name: 'Fraudster' } } }
+
+      it 'converts payload values to Ravelin objects' do
+        expect(event.payload).to include({ dummy: instance_of(MyDummyClass) })
+      end
+    end
+
+    context 'when key not in #object_classes' do
+      let(:payload) { { timestamp: 12345 } }
+
+      it 'leaves payload values alone' do
+        expect(event.payload).to eq({ timestamp: 12345 })
+      end
+    end
+  end
+end

--- a/spec/ravelin/order_spec.rb
+++ b/spec/ravelin/order_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Ravelin::Order do
+  describe '#items=' do
+    let(:order) { described_class.new(order_id: 1, items: items) }
+
+    context 'argument not an array' do
+      let(:items) { 'a string' }
+
+      it 'raises ArgumentError' do
+        expect { order }.to raise_exception(ArgumentError)
+      end
+    end
+
+    context 'argument is an array' do
+      let(:items) { [ { sku: 1, quantity: 1 }, { sku: 2, quantity: 1 }] }
+
+      it 'converts Array items into Ravelin::Items' do
+        expect(order.items).to include(
+          instance_of(Ravelin::Item),
+          instance_of(Ravelin::Item)
+        )
+      end
+    end
+  end
+end

--- a/spec/ravelin/ravelin_object_spec.rb
+++ b/spec/ravelin/ravelin_object_spec.rb
@@ -2,52 +2,66 @@ require 'spec_helper'
 
 describe Ravelin::RavelinObject do
   before do
-    described_class.attr_accessor :email, :full_name
-    described_class.required_attributes :email
+    described_class.attr_accessor :name, :email_address, :address, :street
+    described_class.attr_required :name
   end
 
-  describe '#required_attributes' do
-    it 'sets the #ravelin_required_attributes on the class' do
-      expect(described_class.ravelin_required_attributes).to eq([:email])
+  describe '.required_attributes' do
+    it 'sets the .required_attributes on the class' do
+      expect(described_class.required_attributes).to eq([:name])
     end
   end
 
   describe '#initialize' do
     it 'sets attributes from #new arguments' do
-      obj = described_class.new(email: 'dummy@example.com')
+      obj = described_class.new(name: 'Dummy')
 
-      expect(obj.email).to eq('dummy@example.com')
+      expect(obj.name).to eq('Dummy')
     end
 
-    it 'raises InvalidParametersError for undefined attributes' do
+    it 'raises NoMethodError for undefined attributes' do
       expect {
-        described_class.new(email: 'd@example.com', nickname: 'dummy')
+        described_class.new(name: 'Dummy', nickname: 'dum dum')
       }.to raise_exception(NoMethodError, /nickname/)
     end
   end
 
   describe '#validate' do
-    it 'raises InvalidParametersError for missing attributes' do
+    it 'raises ArgumentError for missing attributes' do
       expect {
-        described_class.new(full_name: 'dummy')
-      }.to raise_exception(Ravelin::InvalidParametersError, /email/)
+        described_class.new(email_address: 'dummy@example.com')
+      }.to raise_exception(ArgumentError, 'missing parameters: name')
     end
   end
 
-  describe '#to_hash' do
+  describe '#serialize' do
     it 'builds a hash object with camelcases the hash keys' do
-      obj = described_class.new(full_name: 'Dummy', email: 'd@example.com')
+      obj = described_class.new(name: 'Dummy', email_address: 'd@example.com')
 
-      expect(obj.to_hash).to eq({
-        'fullName' => 'Dummy',
-        'email' => 'd@example.com'
+      expect(obj.serialize).to eq({
+        'name' => 'Dummy',
+        'emailAddress' => 'd@example.com'
+      })
+    end
+
+    it 'serializes nested Ravelin objects' do
+      obj = described_class.new(name: 'Dummy')
+      allow(obj).to receive(:address).
+        and_return(described_class.new(name: 'Home', street: '123 St.'))
+
+      expect(obj.serialize).to eq({
+        'name' => 'Dummy',
+        'address' => {
+          'name' => 'Home',
+          'street' => '123 St.'
+        }
       })
     end
 
     it 'ignores properties with nil values' do
-      obj = described_class.new(email: 'dummy@example.com')
+      obj = described_class.new(name: 'Dummy')
 
-      expect(obj.to_hash).to eq({ 'email' => 'dummy@example.com' })
+      expect(obj.serialize).to eq({ 'name' => 'Dummy' })
     end
   end
 end

--- a/spec/ravelin/ravelin_object_spec.rb
+++ b/spec/ravelin/ravelin_object_spec.rb
@@ -34,22 +34,22 @@ describe Ravelin::RavelinObject do
     end
   end
 
-  describe '#serialize' do
+  describe '#serializable_hash' do
     it 'builds a hash object with camelcases the hash keys' do
       obj = described_class.new(name: 'Dummy', email_address: 'd@example.com')
 
-      expect(obj.serialize).to eq({
+      expect(obj.serializable_hash).to eq({
         'name' => 'Dummy',
         'emailAddress' => 'd@example.com'
       })
     end
 
-    it 'serializes nested Ravelin objects' do
+    it 'builds hash objects with camelcase keys from nested Ravelin objects' do
       obj = described_class.new(name: 'Dummy')
       allow(obj).to receive(:address).
         and_return(described_class.new(name: 'Home', street: '123 St.'))
 
-      expect(obj.serialize).to eq({
+      expect(obj.serializable_hash).to eq({
         'name' => 'Dummy',
         'address' => {
           'name' => 'Home',
@@ -61,7 +61,7 @@ describe Ravelin::RavelinObject do
     it 'ignores properties with nil values' do
       obj = described_class.new(name: 'Dummy')
 
-      expect(obj.serialize).to eq({ 'name' => 'Dummy' })
+      expect(obj.serializable_hash).to eq({ 'name' => 'Dummy' })
     end
   end
 end

--- a/spec/ravelin/ravelin_object_spec.rb
+++ b/spec/ravelin/ravelin_object_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Ravelin::RavelinObject do
+  before do
+    described_class.attr_accessor :email, :full_name
+    described_class.required_attributes :email
+  end
+
+  describe '#required_attributes' do
+    it 'sets the #ravelin_required_attributes on the class' do
+      expect(described_class.ravelin_required_attributes).to eq([:email])
+    end
+  end
+
+  describe '#initialize' do
+    it 'sets attributes from #new arguments' do
+      obj = described_class.new(email: 'dummy@example.com')
+
+      expect(obj.email).to eq('dummy@example.com')
+    end
+
+    it 'raises InvalidParametersError for undefined attributes' do
+      expect {
+        described_class.new(email: 'd@example.com', nickname: 'dummy')
+      }.to raise_exception(NoMethodError, /nickname/)
+    end
+  end
+
+  describe '#validate' do
+    it 'raises InvalidParametersError for missing attributes' do
+      expect {
+        described_class.new(full_name: 'dummy')
+      }.to raise_exception(Ravelin::InvalidParametersError, /email/)
+    end
+  end
+
+  describe '#to_hash' do
+    it 'builds a hash object with camelcases the hash keys' do
+      obj = described_class.new(full_name: 'Dummy', email: 'd@example.com')
+
+      expect(obj.to_hash).to eq({
+        'fullName' => 'Dummy',
+        'email' => 'd@example.com'
+      })
+    end
+
+    it 'ignores properties with nil values' do
+      obj = described_class.new(email: 'dummy@example.com')
+
+      expect(obj.to_hash).to eq({ 'email' => 'dummy@example.com' })
+    end
+  end
+end

--- a/spec/ravelin/response_spec.rb
+++ b/spec/ravelin/response_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Ravelin::Response do
+  describe '#initialize' do
+    let(:faraday_response) do
+      double('faraday', status: 200, body: {
+        'data' => {
+          'customerId'  => 'cus-123',
+          'action'      => 'SUPPRESS',
+          'score'       => 2,
+          'scoreId'     => 'scr-123',
+          'source'      => 'detective-fraud',
+          'comment'     => 'Looks pretty sketchy'
+        }
+      })
+    end
+    let(:response) { described_class.new(faraday_response) }
+
+    it 'sets the attributes from the response' do
+      expect(response.customer_id).to eq('cus-123')
+      expect(response.action).to eq('SUPPRESS')
+      expect(response.score).to eq(2)
+      expect(response.score_id).to eq('scr-123')
+      expect(response.source).to eq('detective-fraud')
+      expect(response.comment).to eq('Looks pretty sketchy')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ravelin'
+require 'webmock/rspec'


### PR DESCRIPTION
The beginnings of a Ruby gem to send events to Ravlin via their web API. Their API docs can be found here - https://developer.ravelin.com/draft

- [x] Create Ruby gem
- [x] Use the Faraday gem and allow persistent HTTP connections
- [x] Configurable API timeout (default to 1 second)
- [x] Provide a client object that is not a singleton
- [x] Add ability to send all [events](https://developer.ravelin.com/draft/#events) listed in the Ravelin API docs
- [x] Check mandatory arguments are provided to each event
- [x] Parse the response into a `Ravelin::Response` object
- [x] Populate the readme.md
- [x] Set up Travis

[CW-193](https://deliveroo.atlassian.net/browse/CW-193)