### PR TITLE
Conversion of integer attributes suffixed with _id to strings

### DIFF
--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -19,7 +19,9 @@ module Ravelin
     end
 
     def initialize(**args)
-      args.each { |key, value| self.send("#{key}=", value) }
+      args.each do |key, value|
+        self.send("#{key}=", convert_ids_to_strings(key, value))
+      end
 
       validate
     end
@@ -47,6 +49,12 @@ module Ravelin
           hash[key] = value
         end
       end
+    end
+
+    private
+
+    def convert_ids_to_strings(key, value)
+      key.to_s.match(/_id\Z/) && value.is_a?(Integer) ? value.to_s : value
     end
   end
 end

--- a/spec/ravelin/ravelin_object_spec.rb
+++ b/spec/ravelin/ravelin_object_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Ravelin::RavelinObject do
   before do
-    described_class.attr_accessor :name, :email_address, :address, :street
+    described_class.attr_accessor :name, :email_address, :address, :street, :customer_id
     described_class.attr_required :name
   end
 
@@ -23,6 +23,18 @@ describe Ravelin::RavelinObject do
       expect {
         described_class.new(name: 'Dummy', nickname: 'dum dum')
       }.to raise_exception(NoMethodError, /nickname/)
+    end
+
+    it "converts integer attributes suffixed with _id to strings" do
+      obj = described_class.new(name: 'Dummy', customer_id: 123)
+
+      expect(obj.customer_id).to eq('123')
+    end
+
+    it 'leaves integer attributes not suffixed with _id as integers' do
+      obj = described_class.new(name: 'Dummy', street: 123)
+
+      expect(obj.street).to eq(123)
     end
   end
 


### PR DESCRIPTION
Ravelin doesn't accept integer values for id parameters identified by their name being suffixed with `_id`.

The code converts those attribute values to strings if they're integers.