### PR TITLE
CW-195 Fix double splat keyword args bug

### DIFF
--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -18,7 +18,7 @@ module Ravelin
       end
     end
 
-    def initialize(**args)
+    def initialize(args)
       args.each do |key, value|
         self.send("#{key}=", convert_ids_to_strings(key, value))
       end

--- a/spec/ravelin/customer_spec.rb
+++ b/spec/ravelin/customer_spec.rb
@@ -6,7 +6,7 @@ describe Ravelin::Customer do
   end
 
   it 'raises exception when missing required params' do
-    expect { described_class.new }.to raise_exception(
+    expect { described_class.new({}) }.to raise_exception(
       ArgumentError,
       'missing parameters: customer_id'
     )


### PR DESCRIPTION
The double splat `**args` only works for keyword args, so this didn't
work for us as we were passing a Hash in. This commit removes the double
splat, so it takes the full Hash as an arguement. And now @samlevy is 😞.

[CW-195](https://deliveroo.atlassian.net/browse/CW-195)