### PR TITLE
Make score an optional arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ Ravelin.faraday_timeout = 10                    # default is 1 second
 ### Send an event
 
 Events require an event `name` and `payload` as named arguments. There is also an
-optional `timestamp` argument if your event occurred at a different time.
+optional `timestamp` argument if your event occurred at a different time. The score
+argument will return a score for that User from Ravelin.
 
 ```ruby
 client.send_event(
   name: :customer,
   timestamp: Time.now,
+  score: true,
   payload: {
     # ...
   }

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -12,9 +12,12 @@ module Ravelin
     end
 
     def send_event(**args)
+      score = args.delete(:score)
       event = Event.new(**args)
 
-      post("/v2/#{event.name}?score=true", event.serializable_hash)
+      score_param = score ? "?score=true" : nil
+
+      post("/v2/#{event.name}#{score_param}", event.serializable_hash)
     end
 
     def send_backfill_event(**args)

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -32,16 +32,32 @@ describe Ravelin::Client do
       client.send_event(
         name: 'foo',
         timestamp: 12345,
-        payload: { key: 'value' }
+        payload: { key: 'value' },
       )
     end
 
     it 'calls #post with Event payload' do
       allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/v2/foobar?score=true", { id: 'ch-123' })
+      expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' })
 
       client.send_event
+    end
+
+    it 'calls #post with Event payload and score: true' do
+      allow(Ravelin::Event).to receive(:new) { event }
+
+      expect(client).to receive(:post).with("/v2/foobar?score=true", { id: 'ch-123' })
+
+      client.send_event(score: true)
+    end
+
+    it 'calls #post with Event payload and score: false' do
+      allow(Ravelin::Event).to receive(:new) { event }
+
+      expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' })
+
+      client.send_event(score: false)
     end
   end
 
@@ -86,11 +102,10 @@ describe Ravelin::Client do
     end
 
     it 'calls Ravelin with correct headers and body' do
-      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping?score=true').
+      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping').
         with(
           headers: { 'Authorization' => 'token abc' },
           body: { name: 'value' }.to_json,
-          query: { score: true },
         ).and_return(
           headers: { 'Content-Type' => 'application/json' },
           body: '{}'
@@ -104,9 +119,6 @@ describe Ravelin::Client do
     context 'response' do
       before do
         stub_request(:post, 'https://api.ravelin.com/v2/ping').
-          with(
-            query: { score: true },
-          ).
           to_return(
             status: response_status,
             body: '{}'
@@ -153,7 +165,6 @@ describe Ravelin::Client do
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
       stub_request(:post, 'https://api.ravelin.com/v2/ping').
-        with(query: { score: true }).
         and_return(status: status_code, body: "{}")
     end
 


### PR DESCRIPTION
When sending an event to Ravelin, we want to make score optional. This
commit modifies the client to take the `score` arg and use it to add a
query param to the request.