### PR TITLE
Update for Ravelin API changes

### DIFF
--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -43,5 +43,9 @@ module Ravelin
         val.to_time.to_i
       end
     end
+
+    def convert_ids_to_strings(key, value)
+      key.to_s.match(/_id\Z/) && value.is_a?(Integer) ? value.to_s : value
+    end
   end
 end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -39,7 +39,7 @@ module Ravelin
     private
 
     def validate_top_level_payload_params
-      validate_customer_presence_on :order, :items, :paymentmethod,
+      validate_customer_id_presence_on :order, :paymentmethod,
         :pretransaction, :transaction
 
       case self.name
@@ -50,12 +50,12 @@ module Ravelin
         when :login
           validate_payload_inclusion_of :customer_id, :temp_customer_id
         when :checkout
-          validate_payload_inclusion_of :customer, :order, :items,
+          validate_payload_inclusion_of :customer, :order,
             :payment_method, :transaction
       end
     end
 
-    def validate_customer_presence_on(*events)
+    def validate_customer_id_presence_on(*events)
       if events.include?(self.name) && !payload_customer_reference_present?
         raise ArgumentError.
           new(%q{payload missing customer_id or temp_customer_id parameter})
@@ -88,6 +88,7 @@ module Ravelin
     def convert_to_ravelin_objects(payload)
       hash_map(payload) do |k, v|
         k = k.to_sym
+        v = Ravelin.convert_ids_to_strings(k, v)
 
         if v.is_a?(Hash) && klass = object_classes[k]
           [k, klass.new(v)]

--- a/lib/ravelin/payment_method.rb
+++ b/lib/ravelin/payment_method.rb
@@ -6,6 +6,20 @@ module Ravelin
       :banned,
       :active,
       :registration_time,
+      # Only when type = card
+      :instrument_id,
+      :name_on_card,
+      :card_bin,
+      :card_last_four,
+      :card_type,
+      :expiry_month,
+      :expiry_year,
+      :successful_registration,
+      :prepaid_card,
+      :issuer,
+      :country_issued,
+      # Only when type = paypal
+      :email,
       :custom
 
     attr_required :payment_method_id, :method_type

--- a/lib/ravelin/ravelin_object.rb
+++ b/lib/ravelin/ravelin_object.rb
@@ -20,7 +20,7 @@ module Ravelin
 
     def initialize(args)
       args.each do |key, value|
-        self.send("#{key}=", convert_ids_to_strings(key, value))
+        self.send("#{key}=", Ravelin.convert_ids_to_strings(key, value))
       end
 
       validate
@@ -51,12 +51,6 @@ module Ravelin
           hash[key] = value
         end
       end
-    end
-
-    private
-
-    def convert_ids_to_strings(key, value)
-      key.to_s.match(/_id\Z/) && value.is_a?(Integer) ? value.to_s : value
     end
   end
 end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -151,5 +151,13 @@ describe Ravelin::Event do
         expect(event.payload).to eq({ timestamp: 12345 })
       end
     end
+
+    context 'when an _id field is present' do
+      let(:payload) { { customer_id: 123 } }
+
+      it "converts integer attributes suffixed with _id to strings" do
+        expect(event.payload).to eq({ customer_id: '123' })
+      end
+    end
   end
 end


### PR DESCRIPTION
- Removes the `/items` endpoint (deprecated)
- Removes the `items` field in the `/order` endpoint (it's now inside the `order` object)
- Allows `customer` as well as the `customer_id` field for endpoints which require a customer
- Ensures `*_id` fields on the root are also converted to strings

CW-186