### PR TITLE
Transaction key not required for checkout

### DIFF
--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -51,7 +51,7 @@ module Ravelin
           validate_payload_inclusion_of :customer_id, :temp_customer_id
         when :checkout
           validate_payload_inclusion_of :customer, :order,
-            :payment_method, :transaction
+            :payment_method
       end
     end
 


### PR DESCRIPTION
The `transaction` key should not be required on the `/checkout` endpoint
as there are situations where no card transaction occurs (eg. all-voucher
payment). In this case the transaction field will not exist.

CW-186