### PR TITLE
Revert "Transaction key not required for checkout"

### DIFF
--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -51,7 +51,7 @@ module Ravelin
           validate_payload_inclusion_of :customer_id, :temp_customer_id
         when :checkout
           validate_payload_inclusion_of :customer, :order,
-            :payment_method
+            :payment_method, :transaction
       end
     end
 


### PR DESCRIPTION
Reverts deliveroo/ravelin-ruby#11 as the `transaction` field is actually required!