### PR TITLE
Make transaction_id optional

### DIFF
--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -14,8 +14,7 @@ module Ravelin
       :avs_result_code,
       :cvv_result_code
 
-    attr_required :transaction_id,
-      :currency,
+    attr_required :currency,
       :debit,
       :credit,
       :gateway,


### PR DESCRIPTION
In the V2 of the Ravelin API, `transaction_id` is optional.