### PR TITLE
Add Creation and Execution time to order

### DIFF
--- a/lib/ravelin/order.rb
+++ b/lib/ravelin/order.rb
@@ -10,7 +10,9 @@ module Ravelin
       :to,
       :country,
       :market,
-      :custom
+      :custom,
+      :creation_time,
+      :execution_time
 
     attr_required :order_id
 


### PR DESCRIPTION
This need to be specified when backfilling orders. This commit adds them
to the class.