### PR TITLE
CW-754: Add order status to Ravelin

### DIFF
--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -37,10 +37,15 @@ module Ravelin
     end
 
     def datetime_to_epoch(val)
-      if val.respond_to?(:to_i)
+      case val
+      when Date
+        val.to_datetime.to_time.to_i
+      when DateTime
+        val.to_time.to_i
+      when Time
         val.to_i
       else
-        val.to_time.to_i
+        val.to_i
       end
     end
 

--- a/lib/ravelin/order.rb
+++ b/lib/ravelin/order.rb
@@ -12,7 +12,8 @@ module Ravelin
       :market,
       :custom,
       :creation_time,
-      :execution_time
+      :execution_time,
+      :status
 
     attr_required :order_id
 

--- a/spec/ravelin/order_spec.rb
+++ b/spec/ravelin/order_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Ravelin::Order do
   describe '#items=' do
-    let(:order) { described_class.new(order_id: 1, items: items) }
+    let(:order) { described_class.new(order_id: 1, items: items, status: { stage: 'cancelled', reason: 'buyer' }) }
 
     context 'argument not an array' do
       let(:items) { 'a string' }

--- a/spec/ravelin/ravelin_object_spec.rb
+++ b/spec/ravelin/ravelin_object_spec.rb
@@ -79,7 +79,7 @@ describe Ravelin::RavelinObject do
 
   describe '#convert_to_epoch' do
     it 'converts Time to epoch' do
-      obj = described_class.new(name: Time.new(2015,1,1,0,0))
+      obj = described_class.new(name: Time.new(2015,1,1,0,0,0,'+00:00'))
 
       expect(obj.serializable_hash).to eq({ 'name' => 1420070400 })
     end
@@ -91,7 +91,7 @@ describe Ravelin::RavelinObject do
     end
 
     it 'converts DateTime to epoch' do
-      obj = described_class.new(name: DateTime.new(2014,1,1,0,0))
+      obj = described_class.new(name: DateTime.new(2014,1,1,0,0,0,'+00:00'))
 
       expect(obj.serializable_hash).to eq({ 'name' => 1388534400 })
     end


### PR DESCRIPTION
Adds the missing `status` field to orders.

Branches off #16.

Jira story [#CW-754](https://deliveroo.atlassian.net/browse/CW-754).
