### PR TITLE
Add missing fields to Pretransaction Object

### DIFF
--- a/lib/ravelin/pre_transaction.rb
+++ b/lib/ravelin/pre_transaction.rb
@@ -6,6 +6,8 @@ module Ravelin
       :debit,
       :credit,
       :gateway,
+      :type,
+      :time,
       :custom
 
     attr_required :transaction_id, :currency, :debit, :credit, :gateway

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -12,7 +12,9 @@ module Ravelin
       :decline_code,
       :gateway_reference,
       :avs_result_code,
-      :cvv_result_code
+      :cvv_result_code,
+      :type,
+      :time
 
     attr_required :transaction_id,
       :currency,


### PR DESCRIPTION
`type` and `time` are valid pretransition attributes as can be seen on [Ravelin API docs](https://developer.ravelin.com/#post-/v2/pretransaction)
