### PR TITLE
Remove temp_customer_id as a required field from login

### DIFF
--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -49,7 +49,7 @@ module Ravelin
         when :pretransaction, :transaction
           validate_payload_inclusion_of :order_id, :payment_method_id
         when :login
-          validate_payload_inclusion_of :customer_id, :temp_customer_id
+          validate_payload_inclusion_of :customer_id
         when :checkout
           validate_payload_inclusion_of :customer, :order,
             :payment_method, :transaction


### PR DESCRIPTION
Ravelin API docs state the field is optional :
https://developer.ravelin.com/\#post-/v2/login
