### PR TITLE
PAY-1162: Update Ravelin gem to support 3DS

### DIFF
--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -37,6 +37,7 @@ module Ravelin
     attr_accessor :faraday_adapter, :faraday_timeout
 
     def camelize(str)
+      return '3ds' if str == :three_d_secure # hack to get around Ruby not support 3ds an attribute.
       str.to_s.gsub(/_(.)/) { |e| $1.upcase }
     end
 

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -1,27 +1,38 @@
 module Ravelin
   class Transaction < RavelinObject
     attr_accessor :transaction_id,
-      :email,
-      :currency,
-      :debit,
-      :credit,
-      :gateway,
-      :custom,
-      :success,
-      :auth_code,
-      :decline_code,
-      :gateway_reference,
-      :avs_result_code,
-      :cvv_result_code,
-      :type,
-      :time
+                  :email,
+                  :currency,
+                  :debit,
+                  :credit,
+                  :gateway,
+                  :custom,
+                  :success,
+                  :auth_code,
+                  :decline_code,
+                  :gateway_reference,
+                  :avs_result_code,
+                  :cvv_result_code,
+                  :type,
+                  :time,
+                  :three_d_secure
 
     attr_required :transaction_id,
-      :currency,
-      :debit,
-      :credit,
-      :gateway,
-      :gateway_reference,
-      :success
+                  :currency,
+                  :debit,
+                  :credit,
+                  :gateway,
+                  :gateway_reference,
+                  :success
+
+    def initialize(params)
+      three_d_secure_data = params['3ds']
+      unless three_d_secure_data.nil?
+        self.three_d_secure = three_d_secure_data
+        params.delete('3ds')
+      end
+
+      super(params)
+    end
   end
 end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -81,6 +81,39 @@ describe Ravelin::Event do
       end
     end
 
+    context '3ds support' do
+      let(:event) { described_class.new(name: :transaction, payload: payload) }
+      let(:three_d_secure) do
+        {
+          attemped: Time.now,
+          success: true,
+          start_time: Time.now.to_i,
+          end_time: Time.now.to_i
+        }
+      end
+      let(:payload) do
+        {
+          customer_id: 123,
+          payment_method_id: 123,
+          order_id: 123,
+          transaction: {
+            transaction_id: 123,
+            currency: 'GBP',
+            debit: 100,
+            credit: 0,
+            gateway: 'stripe',
+            gateway_reference: 123,
+            success: true,
+            '3ds' => three_d_secure
+          }
+        }
+      end
+
+      it '3ds is included in the output' do
+        expect(event.serializable_hash['transaction']).to include({ '3ds' => three_d_secure })
+      end
+    end
+
     context 'required mutually exclusive params' do
       let(:payload) do
         {


### PR DESCRIPTION
Updated to support `3ds`.

Unfortunately we had to do it a bit hacky because ruby wouldn't support `3ds` as an attribute.

===

Jira story [#PAY-1162](https://deliveroo.atlassian.net/browse/PAY-1162) in project *Payments*:

> ## Why?
> 
> We need to support https://developer.ravelin.com/v2/#3d-secure in the ravelin gem: https://github.com/deliveroo/ravelin-ruby.
> 
> ## What?
> 
> Add functionality, increment version and push to remote gem repos.
> 
> ## Test?
> 
> Will be covered by https://deliveroo.atlassian.net/browse/PAY-539