### PR TITLE
PAY-1162: camelize 3DS payload data

### DIFF
--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -20,6 +20,7 @@ require 'ravelin/location'
 require 'ravelin/order'
 require 'ravelin/payment_method'
 require 'ravelin/pre_transaction'
+require 'ravelin/three_d_secure'
 require 'ravelin/transaction'
 require 'ravelin/voucher'
 require 'ravelin/voucher_redemption'
@@ -36,9 +37,10 @@ module Ravelin
   class << self
     attr_accessor :faraday_adapter, :faraday_timeout
 
-    def camelize(str)
-      return '3ds' if str == :three_d_secure # hack to get around Ruby not support 3ds an attribute.
-      str.to_s.gsub(/_(.)/) { |e| $1.upcase }
+    def camelize(key)
+      return '3ds' if key == :three_d_secure
+
+      key.to_s.gsub(/_(.)/) { Regexp.last_match(1).upcase }
     end
 
     def datetime_to_epoch(val)

--- a/lib/ravelin/three_d_secure.rb
+++ b/lib/ravelin/three_d_secure.rb
@@ -1,0 +1,29 @@
+module Ravelin
+  class ThreeDSecure < RavelinObject
+    attr_accessor :attempted,
+                  :success,
+                  :start_time,
+                  :end_time,
+                  :timed_out
+
+    def serializable_hash
+      {
+        'attempted' => boolean(attempted),
+        'success'   => boolean(success),
+        'startTime' => timestamp(start_time),
+        'endTime'   => timestamp(end_time),
+        'timedOut'  => boolean(timed_out)
+      }
+    end
+
+    private
+
+    def boolean(bool)
+      bool || false
+    end
+
+    def timestamp(time)
+      time.to_i
+    end
+  end
+end

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -26,9 +26,8 @@ module Ravelin
                   :success
 
     def initialize(params)
-      three_d_secure_data = params['3ds']
-      unless three_d_secure_data.nil?
-        self.three_d_secure = three_d_secure_data
+      unless params['3ds'].nil?
+        self.three_d_secure = ThreeDSecure.new(params['3ds'])
         params.delete('3ds')
       end
 

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -83,12 +83,13 @@ describe Ravelin::Event do
 
     context '3ds support' do
       let(:event) { described_class.new(name: :transaction, payload: payload) }
+      let(:timestamp) { Time.now.to_i }
       let(:three_d_secure) do
         {
-          attemped: Time.now,
-          success: true,
-          start_time: Time.now.to_i,
-          end_time: Time.now.to_i
+          attempted:  true,
+          success:    true,
+          start_time: timestamp,
+          end_time:   timestamp
         }
       end
       let(:payload) do
@@ -110,7 +111,17 @@ describe Ravelin::Event do
       end
 
       it '3ds is included in the output' do
-        expect(event.serializable_hash['transaction']).to include({ '3ds' => three_d_secure })
+        serialized_transaction = event.serializable_hash['transaction']
+        serialized_three_d_secure = {
+          '3ds' =>  {
+            'attempted' => true,
+            'success'   => true,
+            'startTime' => timestamp,
+            'endTime'   => timestamp,
+            'timedOut'  => false
+          }
+        }
+        expect(serialized_transaction).to include(serialized_three_d_secure)
       end
     end
 

--- a/spec/ravelin/three_d_secure_spec.rb
+++ b/spec/ravelin/three_d_secure_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Ravelin::ThreeDSecure do
+  let(:timestamp) { Time.new(2017).to_i }
+  let(:params) do
+    {
+      attempted:  true,
+      success:    true,
+      start_time: timestamp,
+      end_time:   timestamp
+    }
+  end
+
+  subject do
+    described_class.new(params)
+  end
+
+  describe '#serializable_hash' do
+    it 'is camelized and well formed' do
+      expect(subject.serializable_hash).to eql(
+        'attempted' => true,
+        'success'   => true,
+        'startTime' => timestamp,
+        'endTime'   => timestamp,
+        'timedOut'  => false
+      )
+    end
+
+    context 'when 3DS has timed out' do
+      let(:params) do
+        {
+          attempted:  true,
+          success:    false,
+          start_time: timestamp,
+          end_time:   nil,
+          timed_out:  true
+        }
+      end
+
+      it 'is still camelized and well formed' do
+        expect(subject.serializable_hash).to eql(
+          'attempted' => true,
+          'success'   => false,
+          'startTime' => timestamp,
+          'endTime'   => 0,
+          'timedOut'  => true
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
We were still sending 3DS data in `snake_case` and needed to send in `camelCase` (see: https://developer.ravelin.com/v2/#3d-secure).

===

Jira story [#PAY-1162](https://deliveroo.atlassian.net/browse/PAY-1162) in project *Payments*:

> ## Why?
> 
> We need to support https://developer.ravelin.com/v2/#3d-secure in the ravelin gem: https://github.com/deliveroo/ravelin-ruby.
> 
> ## What?
> 
> Add functionality, increment version and push to remote gem repos.
> 
> ## Test?
> 
> Will be covered by https://deliveroo.atlassian.net/browse/PAY-539