### PR TITLE
Ensure 3DS events adhere to schema

### DIFF
--- a/lib/ravelin/three_d_secure.rb
+++ b/lib/ravelin/three_d_secure.rb
@@ -10,10 +10,10 @@ module Ravelin
       hash = {
         'attempted' => boolean(attempted),
         'success'   => boolean(success),
-        'startTime' => timestamp(start_time),
         'timedOut'  => boolean(timed_out)
       }
-      hash['endTime'] = timestamp(end_time) unless end_time.nil?
+      hash['startTime'] = timestamp(start_time) if valid?(start_time)
+      hash['endTime']   = timestamp(end_time)   if valid?(end_time)
       hash
     end
 
@@ -25,6 +25,10 @@ module Ravelin
 
     def timestamp(time)
       time.to_i
+    end
+
+    def valid?(time)
+      timestamp(time) >= 100
     end
   end
 end

--- a/lib/ravelin/three_d_secure.rb
+++ b/lib/ravelin/three_d_secure.rb
@@ -7,13 +7,14 @@ module Ravelin
                   :timed_out
 
     def serializable_hash
-      {
+      hash = {
         'attempted' => boolean(attempted),
         'success'   => boolean(success),
         'startTime' => timestamp(start_time),
-        'endTime'   => timestamp(end_time),
         'timedOut'  => boolean(timed_out)
       }
+      hash['endTime'] = timestamp(end_time) unless end_time.nil?
+      hash
     end
 
     private

--- a/spec/ravelin/three_d_secure_spec.rb
+++ b/spec/ravelin/three_d_secure_spec.rb
@@ -6,8 +6,8 @@ describe Ravelin::ThreeDSecure do
     {
       attempted:  true,
       success:    true,
-      start_time: timestamp,
-      end_time:   timestamp
+      start_time: Time.new(2017),
+      end_time:   Time.new(2017)
     }
   end
 
@@ -26,6 +26,27 @@ describe Ravelin::ThreeDSecure do
       )
     end
 
+    context 'when 3DS has not finished yet' do
+      let(:params) do
+        {
+          attempted:  true,
+          success:    false,
+          start_time: timestamp,
+          end_time:   nil,
+          timed_out:  false
+        }
+      end
+
+      it 'does not include the end time' do
+        expect(subject.serializable_hash).to eql(
+          'attempted' => true,
+          'success'   => false,
+          'startTime' => timestamp,
+          'timedOut'  => false
+        )
+      end
+    end
+
     context 'when 3DS has timed out' do
       let(:params) do
         {
@@ -42,7 +63,6 @@ describe Ravelin::ThreeDSecure do
           'attempted' => true,
           'success'   => false,
           'startTime' => timestamp,
-          'endTime'   => 0,
           'timedOut'  => true
         )
       end

--- a/spec/ravelin/three_d_secure_spec.rb
+++ b/spec/ravelin/three_d_secure_spec.rb
@@ -68,4 +68,46 @@ describe Ravelin::ThreeDSecure do
       end
     end
   end
+
+  context 'when invalid timestamps are sent' do
+    let(:less_than_one_hundred) { 99 }
+
+    let(:params) do
+      {
+        attempted:  true,
+        success:    true,
+        start_time: less_than_one_hundred,
+        end_time:   less_than_one_hundred,
+        timed_out:  false
+      }
+    end
+
+    it 'does not include the timestamps' do
+      expect(subject.serializable_hash).to eql(
+        'attempted' => true,
+        'success'   => true,
+        'timedOut'  => false
+      )
+    end
+  end
+
+  context 'when no timestamps are sent' do
+    let(:params) do
+      {
+        attempted:  false,
+        success:    false,
+        start_time: nil,
+        end_time:   nil,
+        timed_out:  false
+      }
+    end
+
+    it 'does not include the timestamps' do
+      expect(subject.serializable_hash).to eql(
+        'attempted' => false,
+        'success'   => false,
+        'timedOut'  => false
+      )
+    end
+  end
 end


### PR DESCRIPTION
If we send `nil` or an integer less that `100` (e.g. `nil.to_i => 0`) for the 3DS start or end times we will break the JSON schema contract. This PR adds some safety to the client, though we still need to be more circumspect with the data we pass when sending events.