### PR TITLE
Add get tags

### DIFF
--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -57,7 +57,7 @@ module Ravelin
       tag = Tag.new(**args).serializable_hash
       customer_id = tag["customerId"]
 
-      get("/v2/tag/customer?customerId=#{customer_id}")
+      get("/v2/tag/customer/#{customer_id}")
     end
 
     private

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -49,8 +49,15 @@ module Ravelin
       tag = Tag.new(**args).serializable_hash
       customer_id = tag["customerId"]
       tags = tag["tagNames"].join(",")
-      
+
       delete("/v2/tag/customer?customerId=#{customer_id}&tagName=#{tags}")
+    end
+
+    def get_tag(**args)
+      tag = Tag.new(**args).serializable_hash
+      customer_id = tag["customerId"]
+
+      get("/v2/tag/customer?customerId=#{customer_id}")
     end
 
     private
@@ -67,6 +74,16 @@ module Ravelin
 
     def delete(url)
       response = @connection.delete(url)
+
+      if response.success?
+        Response.new(response)
+      else
+        handle_error_response(response)
+      end
+    end
+
+    def get(url)
+      response = @connection.get(url)
 
       if response.success?
         Response.new(response)

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -152,6 +152,20 @@ describe Ravelin::Client do
     end
   end
 
+  describe '#get_tag' do
+    include_context 'tag setup and stubbing'
+
+    context 'when deleting one tag' do
+      let(:tag_payload) { { "customerId" => '123' } }
+
+      it 'calls #get with customer id' do
+        allow(Ravelin::Tag).to receive(:new) { tag }
+        expect(client).to receive(:get).with('/v2/tag/customer?customerId=123')
+        client.get_tag
+      end
+    end
+  end
+
   describe '#post' do
     let(:client) { described_class.new(api_key: 'abc') }
     let(:event) do
@@ -220,6 +234,79 @@ describe Ravelin::Client do
             with(kind_of(Faraday::Response))
 
           client.send_event
+        end
+      end
+    end
+  end
+
+  describe '#get' do
+    let(:client) { described_class.new(api_key: 'abc') }
+    let(:tag) do
+      double('tag', name: 'ping', serializable_hash: { name: 'value' })
+    end
+
+    before do
+      allow(Ravelin::Tag).to receive(:new).and_return(tag)
+    end
+
+    it 'calls Ravelin with correct headers and body' do
+      stub = stub_request(:get, 'https://api.ravelin.com/v2/ping').
+          with(
+              headers: { 'Authorization' => 'token abc' },
+              body: { name: 'value' }.to_json,
+              ).and_return(
+          headers: { 'Content-Type' => 'application/json' },
+          body: '{}'
+      )
+
+      client.get_tag
+
+      expect(stub).to have_been_requested
+    end
+
+    context 'response' do
+      before do
+        stub_request(:get, 'https://api.ravelin.com/v2/ping').
+            to_return(
+                status: response_status,
+                body: body
+            )
+      end
+
+      context 'successful' do
+        shared_examples 'successful request' do
+          it 'returns the response' do
+            expect(client.get_tag).to be_a(Ravelin::Response)
+          end
+
+          it "not treated as an error" do
+            expect(client).to_not receive(:handle_error_response)
+
+            client.get_tag
+          end
+        end
+
+        context 'when the response code is 200' do
+          let(:response_status) { 200 }
+          let(:body) { '{}' }
+          it_behaves_like 'successful request'
+        end
+
+        context 'when the response code is 200' do
+          let(:response_status) { 204 }
+          let(:body) { '' }
+          it_behaves_like 'successful request'
+        end
+      end
+
+      context 'error' do
+        let(:response_status) { 400 }
+        let(:body) { '{}' }
+        it 'handles error response' do
+          expect(client).to receive(:handle_error_response).
+              with(kind_of(Faraday::Response))
+
+          client.get_tag
         end
       end
     end

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -161,7 +161,7 @@ describe Ravelin::Client do
 
       it 'calls #get with customer id' do
         allow(Ravelin::Tag).to receive(:new) { tag }
-        expect(client).to receive(:get).with('/v2/tag/customer?customerId=123')
+        expect(client).to receive(:get).with('/v2/tag/customer/123')
         client.get_tag
       end
     end
@@ -323,7 +323,7 @@ describe Ravelin::Client do
     end
 
     it 'calls Ravelin with correct headers and body' do
-      stub = stub_request(:get, 'https://api.ravelin.com/v2/tag/customer?customerId=123').
+      stub = stub_request(:get, 'https://api.ravelin.com/v2/tag/customer/123').
           with(
               headers: { 'Authorization' => 'token abc' }
           ).and_return(
@@ -338,7 +338,7 @@ describe Ravelin::Client do
 
     context 'response' do
       before do
-        stub_request(:get, 'https://api.ravelin.com/v2/tag/customer?customerId=123').
+        stub_request(:get, 'https://api.ravelin.com/v2/tag/customer/123').
             to_return(
                 status: response_status,
                 body: body

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -31,6 +31,7 @@ describe Ravelin::Client do
 
     before { allow(client).to receive(:post) }
     before { allow(client).to receive(:delete) }
+    before { allow(client).to receive(:get) }
   end
 
   describe '#send_event' do
@@ -239,10 +240,10 @@ describe Ravelin::Client do
     end
   end
 
-  describe '#get' do
+  describe '#delete' do
     let(:client) { described_class.new(api_key: 'abc') }
     let(:tag) do
-      double('tag', name: 'ping', serializable_hash: { name: 'value' })
+      double('tag', name: 'ping', serializable_hash: { "customerId" => '123', "tagNames" => ['foo', 'bar'] })
     end
 
     before do
@@ -250,11 +251,82 @@ describe Ravelin::Client do
     end
 
     it 'calls Ravelin with correct headers and body' do
-      stub = stub_request(:get, 'https://api.ravelin.com/v2/ping').
+      stub = stub_request(:delete, 'https://api.ravelin.com/v2/tag/customer?customerId=123&tagName=foo,bar').
           with(
-              headers: { 'Authorization' => 'token abc' },
-              body: { name: 'value' }.to_json,
-              ).and_return(
+              headers: { 'Authorization' => 'token abc' }
+          ).and_return(
+          headers: { 'Content-Type' => 'application/json' },
+          body: '{}'
+      )
+
+      client.delete_tag
+
+      expect(stub).to have_been_requested
+    end
+
+    context 'response' do
+      before do
+        stub_request(:delete, 'https://api.ravelin.com/v2/tag/customer?customerId=123&tagName=foo,bar').
+            to_return(
+                status: response_status,
+                body: body
+            )
+      end
+
+      context 'successful' do
+        shared_examples 'successful request' do
+          it 'returns the response' do
+            expect(client.delete_tag).to be_a(Ravelin::Response)
+          end
+
+          it "not treated as an error" do
+            expect(client).to_not receive(:handle_error_response)
+
+            client.delete_tag
+          end
+        end
+
+        context 'when the response code is 200' do
+          let(:response_status) { 200 }
+          let(:body) { '{}' }
+          it_behaves_like 'successful request'
+        end
+
+        context 'when the response code is 200' do
+          let(:response_status) { 204 }
+          let(:body) { '' }
+          it_behaves_like 'successful request'
+        end
+      end
+
+      context 'error' do
+        let(:response_status) { 400 }
+        let(:body) { '{}' }
+        it 'handles error response' do
+          expect(client).to receive(:handle_error_response).
+              with(kind_of(Faraday::Response))
+
+          client.delete_tag
+        end
+      end
+    end
+  end
+
+  describe '#get' do
+    let(:client) { described_class.new(api_key: 'abc') }
+    let(:tag) do
+      double('tag', name: 'ping', serializable_hash: { "customerId" => '123', "tagNames" => ['foo', 'bar'] })
+    end
+
+    before do
+      allow(Ravelin::Tag).to receive(:new).and_return(tag)
+    end
+
+    it 'calls Ravelin with correct headers and body' do
+      stub = stub_request(:get, 'https://api.ravelin.com/v2/tag/customer?customerId=123').
+          with(
+              headers: { 'Authorization' => 'token abc' }
+          ).and_return(
           headers: { 'Content-Type' => 'application/json' },
           body: '{}'
       )
@@ -266,7 +338,7 @@ describe Ravelin::Client do
 
     context 'response' do
       before do
-        stub_request(:get, 'https://api.ravelin.com/v2/ping').
+        stub_request(:get, 'https://api.ravelin.com/v2/tag/customer?customerId=123').
             to_return(
                 status: response_status,
                 body: body


### PR DESCRIPTION
Adding support for Ravelin's GET tags endpoint. Also fleshing out specs. 
NB: the endpoint is `/v2/tag/customer?customerId=[id]` on the docs but I've confirmed that it's deprecated and that the new format is `/v2/tag/customer/[id]` 