### PR TITLE
AI-12: Add correct formatting of ato reclaim event timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.24
+
+Fix date formatting for events:
+* ATO Login events provide Unix timestamps with milliseconds 
+* ATO Reclaim events provide timestamps in RFC3339 format
+* All other events provide Unix timestamps
+
 # 0.1.23
 
 Add support for ATO reclaim API

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -21,7 +21,7 @@ module Ravelin
         end
       end
 
-      payload_hash.merge('timestamp' => timestamp)
+      payload_hash.merge('timestamp' => format_timestamp(timestamp))
     end
 
     def object_classes
@@ -44,6 +44,17 @@ module Ravelin
       }
     end
 
+    def format_timestamp(timestamp)
+      case name
+      when :login
+        timestamp * 1000
+      when :reclaim
+        Time.at(timestamp).utc.to_datetime.to_s
+      else
+        timestamp
+      end
+    end
+
     private
 
     def validate_top_level_payload_params
@@ -64,6 +75,8 @@ module Ravelin
       when :checkout
         validate_payload_inclusion_of :customer, :order,
           :payment_method, :transaction
+      when :login
+        validate_payload_inclusion_of :login
       when :reclaim
         validate_payload_inclusion_of :customers, :source
       end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.23"
+  VERSION = "0.1.24"
 end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -175,6 +175,78 @@ describe Ravelin::Event do
       end
     end
 
+    context 'ato login' do
+      it 'throws ArgumentError with missing payload parameters' do
+        expect {
+          described_class.new(
+            name: :ato_login,
+            payload: { }
+          )
+        }.to raise_exception(
+                 ArgumentError,
+                 /payload missing parameters: login/
+             )
+      end
+
+      it 'is executed cleanly with required payload parameters' do
+        expect {
+          described_class.new(
+            name: :ato_login,
+            payload: {
+              login: {
+                username: "big.jim@deliveroo.invalid",
+                customer_id: 123,
+                success: true,
+                authentication_mechanism: {
+                  password: {
+                    password: "lol",
+                    success: true
+                  }
+                }
+              }
+            }
+          )
+        }.to_not raise_exception
+      end
+
+      it 'it generates the correct serializable hash' do
+        output = described_class.new(
+          name: :ato_login,
+          payload: {
+            login: {
+              username: "big.jim@deliveroo.invalid",
+              customer_id: 123,
+              success: true,
+              authentication_mechanism: {
+                password: {
+                  password: "lol",
+                  success: true
+                }
+              }
+            }
+          },
+          timestamp: 1586283630
+        ).serializable_hash
+
+        expect(output).to eq(
+          {
+            "login" => {
+              "authenticationMechanism" => {
+                "password" => {
+                  "passwordHashed" => "07123e1f482356c415f684407a3b8723e10b2cbbc0b8fcd6282c49d37c9c1abc",
+                  "success" => true
+                }
+              },
+              "customerId" => "123",
+              "success" => true,
+              "username" => "big.jim@deliveroo.invalid"
+            },
+            "timestamp" => 1586283630000
+          }
+        )
+      end
+    end
+
     context 'account reclamation' do
       it 'throws ArgumentError with missing payload parameters' do
         expect {
@@ -189,9 +261,17 @@ describe Ravelin::Event do
         expect {
           described_class.new(
             name: :ato_reclaim,
-            payload: { customers: [{customer_id: "12345", method: "PasswordReset"}], source: "ATO" }
+            payload: { customers: [{customer_id: "12345", method: "PasswordReset"}], source: "ATO" },
           )
         }.to_not raise_exception
+      end
+
+      it 'it generates the correct serializable hash' do
+        output = described_class.new(name: :ato_reclaim,
+                                     payload: { customers: [{customer_id: "12345", method: "PasswordReset"}], source: "ATO" },
+                                     timestamp: 1586283630)
+                     .serializable_hash
+        expect(output).to eq( {"customers"=>[{:customer_id=>"12345", :method=>"PasswordReset"}], "source"=>"ATO", "timestamp"=>"2020-04-07T18:20:30+00:00"} )
       end
     end
   end


### PR DESCRIPTION
ATO Reclaim Events:
* Corrects formatting for timestamps in `serializable_hash`

ATO Login Events:
* Uses a standardised unix timestamp during creation
* Default timestamp will now be correct
* Adds validation to required fields