### PR TITLE
AI-131: explicitly set score query parameter when calling ravelin login endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.28
+Explicitly set `score=false` query parameter when sending event to Ravelin. 
+
 # 0.1.27
 Reverted the faraday and rspec versions back to the versions that were in the `0.1.25` gem.
 

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -14,7 +14,7 @@ module Ravelin
     def initialize(api_key:, api_version: 2)
       @api_key = api_key
 
-      raise ArgumentError.new("api_version must be 2 or 3") unless [2,3].include? api_version
+      raise ArgumentError.new("api_version must be 2 or 3") unless [2, 3].include? api_version
       @api_version = api_version
 
       @connection = Faraday.new(API_BASE, faraday_options) do |conn|
@@ -27,7 +27,7 @@ module Ravelin
       score = args.delete(:score)
       event = Event.new(**args)
 
-      score_param = score ? "?score=true" : nil
+      score_param = score ? '?score=true' : '?score=false'
 
       post("/v#{@api_version}/#{event.name}#{score_param}", event.serializable_hash)
     end
@@ -110,11 +110,11 @@ module Ravelin
 
     def faraday_options
       {
-        request: { timeout: Ravelin.faraday_timeout },
+        request: {timeout: Ravelin.faraday_timeout},
         headers: {
           'Authorization' => "token #{@api_key}",
-          'Content-Type'  => 'application/json; charset=utf-8'.freeze,
-          'User-Agent'    => "Ravelin RubyGem/#{Ravelin::VERSION}".freeze
+          'Content-Type' => 'application/json; charset=utf-8'.freeze,
+          'User-Agent' => "Ravelin RubyGem/#{Ravelin::VERSION}".freeze
         }
       }
     end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.27"
+  VERSION = "0.1.28"
 end

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -52,7 +52,7 @@ describe Ravelin::Client do
     it 'calls #post with Event payload' do
       allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' })
+      expect(client).to receive(:post).with("/v2/foobar?score=false", { id: 'ch-123' })
 
       client.send_event
     end
@@ -68,7 +68,7 @@ describe Ravelin::Client do
     it 'calls #post with Event payload and score: false' do
       allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' })
+      expect(client).to receive(:post).with("/v2/foobar?score=false", { id: 'ch-123' })
 
       client.send_event(score: false)
     end
@@ -178,7 +178,7 @@ describe Ravelin::Client do
     end
 
     it 'calls Ravelin with correct headers and body' do
-      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping').
+      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping?score=false').
         with(
           headers: { 'Authorization' => 'token abc' },
           body: { name: 'value' }.to_json,
@@ -194,7 +194,7 @@ describe Ravelin::Client do
 
     context 'response' do
       before do
-        stub_request(:post, 'https://api.ravelin.com/v2/ping').
+        stub_request(:post, 'https://api.ravelin.com/v2/ping?score=false').
           to_return(
             status: response_status,
             body: body
@@ -390,7 +390,7 @@ describe Ravelin::Client do
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
-      stub_request(:post, 'https://api.ravelin.com/v2/ping').
+      stub_request(:post, 'https://api.ravelin.com/v2/ping?score=false').
         and_return(status: status_code, body: "null")
     end
 
@@ -415,7 +415,7 @@ describe Ravelin::Client do
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
-      stub_request(:post, 'https://api.ravelin.com/v2/ping').
+      stub_request(:post, 'https://api.ravelin.com/v2/ping?score=false').
         and_return(status: status_code, body: "{}")
     end
 

--- a/spec/ravelin/proxy_client_spec.rb
+++ b/spec/ravelin/proxy_client_spec.rb
@@ -35,7 +35,7 @@ describe Ravelin::ProxyClient do
     it 'calls #post with Event payload' do
       allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/ravelinproxy/v2/foobar", { id: 'ch-123' })
+      expect(client).to receive(:post).with("/ravelinproxy/v2/foobar?score=false", { id: 'ch-123' })
 
       client.send_event
     end
@@ -51,7 +51,7 @@ describe Ravelin::ProxyClient do
     it 'calls #post with Event payload and score: false' do
       allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/ravelinproxy/v2/foobar", { id: 'ch-123' })
+      expect(client).to receive(:post).with("/ravelinproxy/v2/foobar?score=false", { id: 'ch-123' })
 
       client.send_event(score: false)
     end
@@ -168,7 +168,7 @@ describe Ravelin::ProxyClient do
     end
 
     it 'calls Ravelin Proxy with correct headers and body' do
-      stub = stub_request(:post, "#{base_url}/ravelinproxy/v2/ping").
+      stub = stub_request(:post, "#{base_url}/ravelinproxy/v2/ping?score=false").
         with(
           body: { name: 'value' }.to_json,
           headers: headers
@@ -182,7 +182,7 @@ describe Ravelin::ProxyClient do
 
     context 'response' do
       before do
-        stub_request(:post, "#{base_url}/ravelinproxy/v2/ping").
+        stub_request(:post, "#{base_url}/ravelinproxy/v2/ping?score=false").
           to_return(
             status: response_status,
             body: body
@@ -378,7 +378,7 @@ describe Ravelin::ProxyClient do
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
-      stub_request(:post, "#{base_url}/ravelinproxy/v2/ping").
+      stub_request(:post, "#{base_url}/ravelinproxy/v2/ping?score=false").
         and_return(status: status_code, body: "null")
     end
 
@@ -403,7 +403,7 @@ describe Ravelin::ProxyClient do
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
-      stub_request(:post, "#{base_url}/ravelinproxy/v2/ping").
+      stub_request(:post, "#{base_url}/ravelinproxy/v2/ping?score=false").
         and_return(status: status_code, body: "{}")
     end
 


### PR DESCRIPTION
There is a request from ravelin that we be specific about about our score intents when calling the API (instead of ignoring the score param and let it default to false).

This PR implements that change.