### PR TITLE
PRC-101: downgraded faraday dependency versions

### DIFF
--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://developer.ravelin.com'
   spec.license       = 'MIT'
 
-  spec.add_dependency('faraday', '~> 0.17')
-  spec.add_dependency('faraday_middleware', '~> 0.14')
+  spec.add_dependency('faraday', '~> 0.15')
+  spec.add_dependency('faraday_middleware', '~> 0.10')
 
   spec.files         = Dir['lib/**/*.rb']
   spec.bindir        = 'exe'

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 2.3'
 end


### PR DESCRIPTION
## What?
* downgraded faraday dependency versions due to orderweb conflicts
* switched rspec back to it's original version that was before the PRC-101 work.

## Why?
After importing the gem into orderweb, there were faraday dependency issues due to bumping the versions. Really, we only need `webmock` updated.