### PR TITLE
PRC-101: fix dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.27
+Reverted the faraday and rspec versions back to the versions that were in the `0.1.25` gem.
+
 # 0.1.26
 Added an ProxyClient as an alternative client
 * Instead of calling the Ravelin API directly, it can be done via an HTTP proxy server.

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.26"
+  VERSION = "0.1.27"
 end

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://developer.ravelin.com'
   spec.license       = 'MIT'
 
-  spec.add_dependency('faraday', '~> 0.17')
-  spec.add_dependency('faraday_middleware', '~> 0.14')
+  spec.add_dependency('faraday', '~> 0.15')
+  spec.add_dependency('faraday_middleware', '~> 0.10')
 
   spec.files         = Dir['lib/**/*.rb']
   spec.bindir        = 'exe'

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 2.3'
 end


### PR DESCRIPTION
## What?
* downgraded faraday dependency versions due to orderweb conflicts
* switched rspec back to it's original version that was before the PRC-101 work.

## Why?
After importing the gem into orderweb, there were faraday dependency issues due to bumping the versions. Really, we only need `webmock` updated.