### PR TITLE
PRC-107: return warnings from Ravelin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.28
+Added returning warning messages in the structured response.
+
 # 0.1.27
 Reverted the faraday and rspec versions back to the versions that were in the `0.1.25` gem.
 

--- a/lib/ravelin/response.rb
+++ b/lib/ravelin/response.rb
@@ -12,7 +12,8 @@ module Ravelin
       :tag_names,
       :tags,
       :http_status,
-      :http_body
+      :http_body,
+      :warnings
 
     def initialize(faraday_response)
       return if faraday_response.body.nil? || faraday_response.body.empty?
@@ -36,6 +37,7 @@ module Ravelin
       @source       = data['source']
       @comment      = data['comment']
       @customer_id  = data['customerId']
+      @warnings     = data['warnings']
     end
 
     def tag(response_body)

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.27"
+  VERSION = "0.1.28"
 end

--- a/spec/ravelin/response_spec.rb
+++ b/spec/ravelin/response_spec.rb
@@ -92,47 +92,5 @@ describe Ravelin::Response do
         expect(response.warnings.last['msg']).to eq("Order \"25857597\" does not have a price.")
       end
     end
-
-    context 'when Ravelin returns warnings' do
-      let(:faraday_response) do
-        double('faraday', status: 200, body: {
-          'data' => {
-            'warnings'    => [
-              {
-                'class' => 'customer-absent-email',
-                'help' => 'https://developer.ravelin.com/apis/warnings/#customer-absent-email',
-                'msg' => "Customer \"eg-cust-a1\" does not have an email address."
-              },
-              {
-                'class' => 'customer-absent-reg-time',
-                'help' => 'https://developer.ravelin.com/apis/warnings/#customer-absent-reg-time',
-                'msg' => "Customer \"eg-cust-a1\" does not have a registration time."
-              },
-              {
-                'class' => 'order-absent-price',
-                'help' => 'https://developer.ravelin.com/apis/warnings/#order-absent-price',
-                'msg' => "Order \"25857597\" does not have a price."
-              }
-            ]
-          }
-        })
-      end
-
-      it('returns the correct number of warnings') do
-        expect(response.warnings.count).to eq(3)
-      end
-
-      it('returns the correct details for the first warning') do
-        expect(response.warnings.first['class']).to eq('customer-absent-email')
-        expect(response.warnings.first['help']).to eq('https://developer.ravelin.com/apis/warnings/#customer-absent-email')
-        expect(response.warnings.first['msg']).to eq("Customer \"eg-cust-a1\" does not have an email address.")
-      end
-
-      it('returns the correct details for the last warning') do
-        expect(response.warnings.last['class']).to eq('order-absent-price')
-        expect(response.warnings.last['help']).to eq('https://developer.ravelin.com/apis/warnings/#order-absent-price')
-        expect(response.warnings.last['msg']).to eq("Order \"25857597\" does not have a price.")
-      end
-    end
   end
 end

--- a/spec/ravelin/response_spec.rb
+++ b/spec/ravelin/response_spec.rb
@@ -51,19 +51,19 @@ describe Ravelin::Response do
           'data' => {
             'warnings'    => [
               {
-                "class" => "customer-absent-email",
-                "help" => "https://developer.ravelin.com/apis/warnings/#customer-absent-email",
-                "msg" => "Customer \"eg-cust-a1\" does not have an email address."
+                'class' => 'customer-absent-email',
+                'help' => 'https://developer.ravelin.com/apis/warnings/#customer-absent-email',
+                'msg' => "Customer \"eg-cust-a1\" does not have an email address."
               },
               {
-                "class" => "customer-absent-reg-time",
-                "help" => "https://developer.ravelin.com/apis/warnings/#customer-absent-reg-time",
-                "msg" => "Customer \"eg-cust-a1\" does not have a registration time."
+                'class' => 'customer-absent-reg-time',
+                'help' => 'https://developer.ravelin.com/apis/warnings/#customer-absent-reg-time',
+                'msg' => "Customer \"eg-cust-a1\" does not have a registration time."
               },
               {
-                "class" => "order-absent-price",
-                "help" => "https://developer.ravelin.com/apis/warnings/#order-absent-price",
-                "msg" => "Order \"25857597\" does not have a price."
+                'class' => 'order-absent-price',
+                'help' => 'https://developer.ravelin.com/apis/warnings/#order-absent-price',
+                'msg' => "Order \"25857597\" does not have a price."
               }
             ]
           }
@@ -72,6 +72,18 @@ describe Ravelin::Response do
 
       it('returns the correct number of warnings') do
         expect(response.warnings.count).to eq(3)
+      end
+
+      it('returns the correct details for the first warning') do
+        expect(response.warnings.first['class']).to eq('customer-absent-email')
+        expect(response.warnings.first['help']).to eq('https://developer.ravelin.com/apis/warnings/#customer-absent-email')
+        expect(response.warnings.first['msg']).to eq("Customer \"eg-cust-a1\" does not have an email address.")
+      end
+
+      it('returns the correct details for the last warning') do
+        expect(response.warnings.last['class']).to eq('order-absent-price')
+        expect(response.warnings.last['help']).to eq('https://developer.ravelin.com/apis/warnings/#order-absent-price')
+        expect(response.warnings.last['msg']).to eq("Order \"25857597\" does not have a price.")
       end
     end
   end

--- a/spec/ravelin/response_spec.rb
+++ b/spec/ravelin/response_spec.rb
@@ -25,6 +25,12 @@ describe Ravelin::Response do
         expect(response.source).to eq('detective-fraud')
         expect(response.comment).to eq('Looks pretty sketchy')
       end
+
+      context 'when the response does not include warnings' do
+        it 'does not set the warnings' do
+          expect(response.warnings).to be_nil
+        end
+      end
     end
 
     context 'when a tag is sent' do
@@ -42,6 +48,48 @@ describe Ravelin::Response do
         expect(response.label).to eq('GENUINE')
         expect(response.tags).to eq('1234abc')
         expect(response.client_reviewed_status).to eq(-1)
+      end
+    end
+
+    context 'when Ravelin returns warnings' do
+      let(:faraday_response) do
+        double('faraday', status: 200, body: {
+          'data' => {
+            'warnings'    => [
+              {
+                'class' => 'customer-absent-email',
+                'help' => 'https://developer.ravelin.com/apis/warnings/#customer-absent-email',
+                'msg' => "Customer \"eg-cust-a1\" does not have an email address."
+              },
+              {
+                'class' => 'customer-absent-reg-time',
+                'help' => 'https://developer.ravelin.com/apis/warnings/#customer-absent-reg-time',
+                'msg' => "Customer \"eg-cust-a1\" does not have a registration time."
+              },
+              {
+                'class' => 'order-absent-price',
+                'help' => 'https://developer.ravelin.com/apis/warnings/#order-absent-price',
+                'msg' => "Order \"25857597\" does not have a price."
+              }
+            ]
+          }
+        })
+      end
+
+      it('returns the correct number of warnings') do
+        expect(response.warnings.count).to eq(3)
+      end
+
+      it('returns the correct details for the first warning') do
+        expect(response.warnings.first['class']).to eq('customer-absent-email')
+        expect(response.warnings.first['help']).to eq('https://developer.ravelin.com/apis/warnings/#customer-absent-email')
+        expect(response.warnings.first['msg']).to eq("Customer \"eg-cust-a1\" does not have an email address.")
+      end
+
+      it('returns the correct details for the last warning') do
+        expect(response.warnings.last['class']).to eq('order-absent-price')
+        expect(response.warnings.last['help']).to eq('https://developer.ravelin.com/apis/warnings/#order-absent-price')
+        expect(response.warnings.last['msg']).to eq("Order \"25857597\" does not have a price.")
       end
     end
 

--- a/spec/ravelin/response_spec.rb
+++ b/spec/ravelin/response_spec.rb
@@ -44,5 +44,35 @@ describe Ravelin::Response do
         expect(response.client_reviewed_status).to eq(-1)
       end
     end
+
+    context 'when Ravelin returns warnings' do
+      let(:faraday_response) do
+        double('faraday', status: 200, body: {
+          'data' => {
+            'warnings'    => [
+              {
+                "class" => "customer-absent-email",
+                "help" => "https://developer.ravelin.com/apis/warnings/#customer-absent-email",
+                "msg" => "Customer \"eg-cust-a1\" does not have an email address."
+              },
+              {
+                "class" => "customer-absent-reg-time",
+                "help" => "https://developer.ravelin.com/apis/warnings/#customer-absent-reg-time",
+                "msg" => "Customer \"eg-cust-a1\" does not have a registration time."
+              },
+              {
+                "class" => "order-absent-price",
+                "help" => "https://developer.ravelin.com/apis/warnings/#order-absent-price",
+                "msg" => "Order \"25857597\" does not have a price."
+              }
+            ]
+          }
+        })
+      end
+
+      it('returns the correct number of warnings') do
+        expect(response.warnings.count).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What?
Update the response in the Ravelin gem to include the warnings as a structured `warnings` field.

## Why?
We are going to push metrics when we receive warnings from Ravelin. After coding this in orderweb, I realised that we should update the Ravelin gem instead of doing this based off the body that is returned.