### PR TITLE
Update required fields for all in one checkout API

### DIFF
--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -73,9 +73,6 @@ module Ravelin
           :payment_method_id, :payment_method
         )
         validate_payload_inclusion_of :order_id
-      when :checkout
-        validate_payload_inclusion_of :customer, :order,
-          :payment_method, :transaction
       when :login
         validate_payload_inclusion_of :username, :success, :authentication_mechanism
       when :ato_login


### PR DESCRIPTION
# What

The API documentation for the all in one Ravelin checkout API (https://developer.ravelin.com/apis/v2/#postv2checkout) lists the fields are `important` rather than `required`:

- customer
- order
- payment_method
- transaction

This PR removes usage of `validate_payload_inclusion_of` to match the spec.