### PR TITLE
TRUST-606: Add a basic circleci config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.5.6
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
+      - run:
+          name: test
+          command: |
+            bundle exec rake spec
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build


### PR DESCRIPTION
Adds a circleci config file.

Using travis recently has been an exercise in extreme patience as the queue time is astronomical.

I've tested this locally with `circleci local execute` and it seems to work. Can't convince circle to run this branch though.