### PR TITLE
Trust 603: remove gateway as required

### DIFF
--- a/lib/ravelin/checkout_transaction.rb
+++ b/lib/ravelin/checkout_transaction.rb
@@ -19,6 +19,6 @@ module Ravelin
                   :time,
                   :three_d_secure
 
-    attr_required :transaction_id, :currency, :debit, :credit, :gateway
+    attr_required :transaction_id, :currency, :debit, :credit
   end
 end

--- a/lib/ravelin/pre_transaction.rb
+++ b/lib/ravelin/pre_transaction.rb
@@ -10,6 +10,6 @@ module Ravelin
       :time,
       :custom
 
-    attr_required :transaction_id, :currency, :debit, :credit, :gateway
+    attr_required :transaction_id, :currency, :debit, :credit
   end
 end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.31'
+  VERSION = '0.1.32'
 end


### PR DESCRIPTION
Gateway is not required pre transaction as it is not always know. As the Ravelin docs say "Usually only available after attempting the payment."