### PR TITLE
TRUST-933: Add a include_rule_output option

### DIFF
--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -11,9 +11,10 @@ module Ravelin
   class Client
     API_BASE = 'https://api.ravelin.com'
 
-    def initialize(api_key:, api_version: 2)
+    def initialize(api_key:, api_version: 2, include_rule_output: false)
       @api_key = api_key
       @url_prefix = ''
+      @include_rule_output = include_rule_output
 
       raise ArgumentError.new("api_version must be 2 or 3") unless [2,3].include? api_version
       @api_version = api_version
@@ -110,7 +111,7 @@ module Ravelin
     end
 
     def faraday_options
-      {
+      options = {
         request: { timeout: Ravelin.faraday_timeout },
         headers: {
           'Authorization' => "token #{@api_key}",
@@ -118,6 +119,12 @@ module Ravelin
           'User-Agent'    => "Ravelin RubyGem/#{Ravelin::VERSION}".freeze
         }
       }
+
+      if @include_rule_output
+        options[:headers]['Accept'] = 'application/vnd.ravelin.score.v2+json'
+      end
+
+      options
     end
   end
 end

--- a/lib/ravelin/proxy_client.rb
+++ b/lib/ravelin/proxy_client.rb
@@ -1,10 +1,11 @@
 module Ravelin
   class ProxyClient < Client
-    def initialize(base_url:, username:, password:, api_version: 2)
+    def initialize(base_url:, username:, password:, api_version: 2, include_rule_output: false)
 
       raise ArgumentError, "api_version must be 2 or 3" unless [2,3].include? api_version
       @api_version = api_version
       @url_prefix = '/ravelinproxy'
+      @include_rule_output = include_rule_output
 
       @connection = Faraday.new(base_url, faraday_proxy_options) do |conn|
         conn.response :json, context_type: /\bjson$/
@@ -14,13 +15,17 @@ module Ravelin
     end
 
     def faraday_proxy_options
-      {
+      options = {
         request: { timeout: Ravelin.faraday_timeout },
         headers: {
           'Content-Type'  => 'application/json; charset=utf-8'.freeze,
           'User-Agent'    => "Ravelin Proxy RubyGem/#{Ravelin::VERSION}".freeze
         }
       }
+      if @include_rule_output
+        options[:headers]['Accept'] = 'application/vnd.ravelin.score.v2+json'
+      end
+      options
     end
   end
 end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.37'
+  VERSION = '0.1.38'
 end

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -8,6 +8,17 @@ describe Ravelin::Client do
 
       described_class.new(api_key: 'abc')
     end
+
+    context 'when include_rule_output is true' do
+      it 'sets the Accept header' do
+        expect(Faraday).to receive(:new).
+          with('https://api.ravelin.com', hash_including(:headers => hash_including('Accept' => "application/vnd.ravelin.score.v2+json")))
+
+        described_class.new(api_key: 'abc', include_rule_output: true)
+      end
+
+    end
+
   end
 
   let(:client) { described_class.new(api_key: 'abc') }

--- a/spec/ravelin/proxy_client_spec.rb
+++ b/spec/ravelin/proxy_client_spec.rb
@@ -13,6 +13,17 @@ describe Ravelin::ProxyClient do
 
       described_class.new(base_url: base_url, username: username, password: password)
     end
+
+    context 'when include_rule_output is true' do
+      it 'sets the Accept header' do
+        expect(Faraday).to receive(:new).
+          with(base_url, hash_including(:headers => hash_including('Accept' => "application/vnd.ravelin.score.v2+json")))
+
+        described_class.new(base_url: base_url, username: username, password: password, include_rule_output: true)
+      end
+
+    end
+
   end
 
   let(:client) { described_class.new(base_url: base_url, username: username, password: password) }


### PR DESCRIPTION
When set this sets the accept header so that Ravelin will include the rule output.

Tested locally by initialising a client with the sandbox key and sending a request. 

```
client = Ravelin::Client.new(api_key: key, include_rule_output: true)
client.send_event(name: :customer, score: true, payload: { customer: {customer_id: 'XXXX', given_name:  'John', family_name: 'Doe'} })
```

Rule output came through (not including incase it is sensitive, even though it is sandbox) Payload available on Ravelin - https://deliveroo-sandbox.ravelin.com/developer/logs?customer=6327060
