### PR TITLE
[TRUST-758] Add custom property on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.39
+
+Adds support for the `custom` property on the `Ravelin::Login` class
+
+# 0.1.38
+
+Add a include_rule_output option
+
 # 0.1.37
 
 Fixes order category from 0.1.36
@@ -72,4 +80,3 @@ Add missing fields to Pretransaction Object
 # 0.1.4
 
 Ravelin sends the work `null` in responses if there are no changes.  This causes JSON.parse to fail.
-

--- a/lib/ravelin/login.rb
+++ b/lib/ravelin/login.rb
@@ -3,7 +3,8 @@ module Ravelin
     attr_accessor :username,
       :customer_id,
       :success,
-      :authentication_mechanism
+      :authentication_mechanism,
+      :custom
 
     attr_required :username, :success, :authentication_mechanism
 

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.38'
+  VERSION = '0.1.39'
 end

--- a/spec/ravelin/login_spec.rb
+++ b/spec/ravelin/login_spec.rb
@@ -12,6 +12,9 @@ describe Ravelin::Login do
             password: "lol",
             success: true
           }
+        },
+        custom: {
+          decision_id: '0123456789abcdef01234589abcdef'
         }
       }
     )


### PR DESCRIPTION
In order to be able to connect the request from `orderweb` with the notification or decision taken by Ravelin, we need to send the generated `decision_id` when calling Ravelin's API.
The `Ravelin::Login` object currently doesn't support the `custom` property that the API supports.

This PR solves just that, by adding the optional field to the object.