### PR TITLE
[TRUST-351] Add support for social login authentication mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.41
+
+Add [social authenication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 
+object
+
 # 0.1.40
 
 Add [supplier](https://developer.ravelin.com/apis/v2/#postv2supplier) object
@@ -84,4 +89,3 @@ Add missing fields to Pretransaction Object
 # 0.1.4
 
 Ravelin sends the work `null` in responses if there are no changes.  This causes JSON.parse to fail.
-

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -40,6 +40,9 @@ require 'ravelin/response'
 require 'ravelin/client'
 require 'ravelin/proxy_client'
 
+require 'ravelin/authentication_mechanisms/social'
+
+
 module Ravelin
   @faraday_adapter = Faraday.default_adapter
   @faraday_timeout = 1

--- a/lib/ravelin/authentication_mechanism.rb
+++ b/lib/ravelin/authentication_mechanism.rb
@@ -12,5 +12,9 @@ module Ravelin
     def password=(passwd)
       @password = Ravelin::Password.new(passwd)
     end
+
+    def social=(mechanism)
+      @social = Ravelin::AuthenticationMechanisms::Social(mechanism)
+    end
   end
 end

--- a/lib/ravelin/authentication_mechanisms/social.rb
+++ b/lib/ravelin/authentication_mechanisms/social.rb
@@ -1,0 +1,31 @@
+module Ravelin
+  module AuthenticationMechanisms
+    class Social < RavelinObject
+      PROVIDERS = %w(apple azure facebook google linkedin microsoft okta onelogin ping twitter)
+      FAILURE_REASONS = %w(TIMEOUT UNKNOWN_USERNAME INTERNAL_ERROR RATE_LIMIT SOCIAL_FAILURE BANNED_USER)
+
+      attr_accessor :success, :social_provider, :failure_reason
+      attr_required :success, :social_provider
+
+      def social_provider=(provider)
+        @social_provider = provider.to_s.downcase
+      end
+
+      def failure_reason=(reason)
+        @failure_reason = reason.to_s.upcase
+      end
+
+      def validate
+        super
+
+        if !success && !FAILURE_REASONS.include?(failure_reason)
+          raise ArgumentError.new("Failure reason value must be one of #{FAILURE_REASONS.join(', ')}")
+        end
+
+        if !PROVIDERS.include?(social_provider)
+          raise ArgumentError.new("Social provider value must be one of #{PROVIDERS.join(', ')}")
+        end
+      end
+    end
+  end
+end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.40'
+  VERSION = '0.1.41'
 end

--- a/spec/ravelin/authentication_mechanisms/social_spec.rb
+++ b/spec/ravelin/authentication_mechanisms/social_spec.rb
@@ -7,7 +7,6 @@ describe Ravelin::AuthenticationMechanisms::Social do
       success: true,
     )
   }
-  let(:expected_hash) { 'daaad6e5604e8e17bd9f108d91e26afe6281dac8fda0091040a7a6d7bd9b43b5' }
 
   context 'creates instance with valid params and no failure' do
     it { expect { subject }.to_not raise_exception }

--- a/spec/ravelin/authentication_mechanisms/social_spec.rb
+++ b/spec/ravelin/authentication_mechanisms/social_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Ravelin::AuthenticationMechanisms::Social do
+  subject {
+    described_class.new(
+      social_provider: 'google',
+      success: true,
+    )
+  }
+  let(:expected_hash) { 'daaad6e5604e8e17bd9f108d91e26afe6281dac8fda0091040a7a6d7bd9b43b5' }
+
+  context 'creates instance with valid params and no failure' do
+    it { expect { subject }.to_not raise_exception }
+  end
+
+  context 'creates instance with valid params and failure' do
+    subject { described_class.new(social_provider: 'google', success: false, failure_reason: 'UNKNOWN_USERNAME') }
+    it { expect { subject }.to_not raise_exception }
+  end
+
+  context 'fails if the result is failure and no failure reason is provided' do
+    subject { described_class.new(social_provider: 'google', success: false) }
+    it { expect { subject }.to raise_error(ArgumentError).with_message(/Failure reason value must be one of/)}
+  end
+
+  context 'fails if the failure reason is not in the list of accepted reasons' do
+    subject { described_class.new(social_provider: 'google', success: false, failure_reason: 'bogus') }
+    it { expect { subject }.to raise_error(ArgumentError).with_message(/Failure reason value must be one of/)}
+  end
+
+  context 'fails if the social provider is not in the list of accepted providers' do
+    subject { described_class.new(social_provider: 'bogus', success: true) }
+    it { expect { subject }.to raise_error(ArgumentError).with_message(/Social provider value must be one of/)}
+  end
+end


### PR DESCRIPTION
This PR adds support for the social login authentication mechanism. 
More info about the API signature can be found here: https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social