### PR TITLE
Fix Ravelin::AuthenticationMechanisms::Social object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.41.1
+
+Fix [social authenication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 
+object
+
+Add tests
+
 # 0.1.41
 
 Add [social authenication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 

--- a/lib/ravelin/authentication_mechanism.rb
+++ b/lib/ravelin/authentication_mechanism.rb
@@ -14,7 +14,7 @@ module Ravelin
     end
 
     def social=(mechanism)
-      @social = Ravelin::AuthenticationMechanisms::Social(mechanism)
+      @social = Ravelin::AuthenticationMechanisms::Social.new(mechanism)
     end
   end
 end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -37,6 +37,7 @@ module Ravelin
         login:                    Login,
         order:                    Order,
         password:                 Password,
+        social:                   AuthenticationMechanisms::Social,
         payment_method:           PaymentMethod,
         supplier:                 Supplier,
         voucher_redemption:       VoucherRedemption,

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.41'
+  VERSION = '0.1.41.1'
 end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.41.1'
+  VERSION = '0.1.42'
 end

--- a/spec/ravelin/authentication_mechanism_spec.rb
+++ b/spec/ravelin/authentication_mechanism_spec.rb
@@ -1,22 +1,44 @@
 require 'spec_helper'
 
 describe Ravelin::AuthenticationMechanism do
-  subject do
-    described_class.new(
-      {
-        password: {
-          password: "lol",
-          success: true
+  context 'for password authentication mechanisms' do
+    subject do
+      described_class.new(
+        {
+          password: {
+            password: "lol",
+            success: true
+          }
         }
-      }
-    )
+      )
+    end
+
+    context 'creates instance with valid params' do
+      it { expect { subject }.to_not raise_exception }
+    end
+
+    context 'creates a password object' do
+      it { expect(subject.password.success).to eq(true) }
+    end
   end
 
-  context 'creates instance with valid params' do
-    it { expect { subject }.to_not raise_exception }
-  end
+  context 'for social authentication mechanisms' do
+    subject do
+      described_class.new(
+        social: {
+          success: false,
+          social_provider: 'GOOGLE',
+          failure_reason: 'SOCIAL_FAILURE'
+        }
+      )
+    end
 
-  context 'creates a password object' do
-    it { expect(subject.password.success).to eq(true) }
+    it 'creates instance with valid params' do
+      expect { subject }.to_not raise_exception
+    end
+
+    it 'creates a social object' do
+      expect(subject.social.success).to eq(false)
+    end
   end
 end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -183,7 +183,7 @@ describe Ravelin::Event do
           success: true,
           authentication_mechanism: {
             password: {
-              password: 'lol',
+              password: 'super-secret-password',
               success: true
             }
           }
@@ -222,7 +222,7 @@ describe Ravelin::Event do
           {
             'authenticationMechanism' => {
               'password' => {
-                'passwordHashed' => '07123e1f482356c415f684407a3b8723e10b2cbbc0b8fcd6282c49d37c9c1abc',
+                'passwordHashed' => '5c76fcf4400da3b4804d70b91af20703d483f2c5860cc2f8d59592a1da8d2121',
                 'success' => true
               }
             },
@@ -253,7 +253,7 @@ describe Ravelin::Event do
             success: true,
             authentication_mechanism: {
               password: {
-                password: 'lol',
+                password: 'super-secret-password',
                 success: true
               }
             }
@@ -294,7 +294,7 @@ describe Ravelin::Event do
             "login" => {
               "authenticationMechanism" => {
                 "password" => {
-                  "passwordHashed" => "07123e1f482356c415f684407a3b8723e10b2cbbc0b8fcd6282c49d37c9c1abc",
+                  "passwordHashed" => "5c76fcf4400da3b4804d70b91af20703d483f2c5860cc2f8d59592a1da8d2121",
                   "success" => true
                 }
               },


### PR DESCRIPTION
The implementation of the `Ravelin::AuthenticationMechanisms::Social` object was incorrect, and the way that the tests were created did not detect the error.
This PR addresses that bug, as well as correctly creating the full login object tree when it is initialised with an hash containing the social authentication mechanism.