### PR TITLE
Add SmsCode authentication mechanism to ATO login request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
-# 0.1.41.1
+# 0.1.43
 
-Fix [social authenication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 
+
+Add [sms code authentication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.smsCode) 
+object
+
+# 0.1.42
+
+Fix [social authentication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 
 object
 
 Add tests
 
 # 0.1.41
 
-Add [social authenication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 
+Add [social authentication mechanism](https://developer.ravelin.com/apis/ato/#login.login.authenticationMechanism.social) 
 object
 
 # 0.1.40

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -41,6 +41,7 @@ require 'ravelin/client'
 require 'ravelin/proxy_client'
 
 require 'ravelin/authentication_mechanisms/social'
+require 'ravelin/authentication_mechanisms/sms_code'
 
 
 module Ravelin

--- a/lib/ravelin/authentication_mechanism.rb
+++ b/lib/ravelin/authentication_mechanism.rb
@@ -16,5 +16,9 @@ module Ravelin
     def social=(mechanism)
       @social = Ravelin::AuthenticationMechanisms::Social.new(mechanism)
     end
+
+    def sms_code=(mechanism)
+      @sms_code = Ravelin::AuthenticationMechanisms::SmsCode.new(mechanism)
+    end
   end
 end

--- a/lib/ravelin/authentication_mechanisms/sms_code.rb
+++ b/lib/ravelin/authentication_mechanisms/sms_code.rb
@@ -1,0 +1,22 @@
+module Ravelin
+  module AuthenticationMechanisms
+    class SmsCode < RavelinObject
+      FAILURE_REASONS = %w(INVALID_CODE CODE_TIMEOUT INTERNAL_ERROR RATE_LIMIT BANNED_USER AUTHENTICATION_FAILURE)
+
+      attr_accessor :success, :phone_number, :failure_reason
+      attr_required :success, :phone_number
+
+      def failure_reason=(reason)
+        @failure_reason = reason.to_s.upcase
+      end
+
+      def validate
+        super
+
+        if !success && !FAILURE_REASONS.include?(failure_reason)
+          raise ArgumentError.new("Failure reason value must be one of #{FAILURE_REASONS.join(', ')}")
+        end
+      end
+    end
+  end
+end

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -38,6 +38,7 @@ module Ravelin
         order:                    Order,
         password:                 Password,
         social:                   AuthenticationMechanisms::Social,
+        sms_code:                 AuthenticationMechanisms::SmsCode,
         payment_method:           PaymentMethod,
         supplier:                 Supplier,
         voucher_redemption:       VoucherRedemption,

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.42'
+  VERSION = '0.1.43'
 end

--- a/spec/ravelin/authentication_mechanism_spec.rb
+++ b/spec/ravelin/authentication_mechanism_spec.rb
@@ -6,7 +6,7 @@ describe Ravelin::AuthenticationMechanism do
       described_class.new(
         {
           password: {
-            password: "lol",
+            password: "super-secret-password",
             success: true
           }
         }
@@ -39,6 +39,26 @@ describe Ravelin::AuthenticationMechanism do
 
     it 'creates a social object' do
       expect(subject.social.success).to eq(false)
+    end
+  end
+
+  context 'for sms code authentication mechanisms' do
+    subject do
+      described_class.new(
+        sms_code: {
+          success: false,
+          phone_number: '+447123456789',
+          failure_reason: 'INVALID_CODE'
+        }
+      )
+    end
+
+    it 'creates instance with valid params' do
+      expect { subject }.to_not raise_exception
+    end
+
+    it 'creates a sms code object' do
+      expect(subject.sms_code.success).to eq(false)
     end
   end
 end

--- a/spec/ravelin/authentication_mechanisms/sms_code_spec.rb
+++ b/spec/ravelin/authentication_mechanisms/sms_code_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Ravelin::AuthenticationMechanisms::SmsCode do
+  context 'creates instance with valid params and no failure' do
+    subject { described_class.new(phone_number: '+447123456789', success: true) }
+    it { expect { subject }.to_not raise_exception }
+  end
+
+  context 'creates instance with valid params and failure' do
+    subject { described_class.new(phone_number: '+447123456789', success: false, failure_reason: 'INVALID_CODE') }
+    it { expect { subject }.to_not raise_exception }
+  end
+
+  context 'fails if the result is failure and no failure reason is provided' do
+    subject { described_class.new(phone_number: '+447123456789', success: false) }
+    it { expect { subject }.to raise_error(ArgumentError).with_message(/Failure reason value must be one of/)}
+  end
+
+  context 'fails if the failure reason is not in the list of accepted reasons' do
+    subject { described_class.new(phone_number: '+447123456789', success: false, failure_reason: 'bogus') }
+    it { expect { subject }.to raise_error(ArgumentError).with_message(/Failure reason value must be one of/)}
+  end
+end


### PR DESCRIPTION
This PR adds the object that is required to signal a SMS code login.

Some fixes to the changelog are also included