### PR TITLE
TRST-XXX: Update bundler version to 2.0.0 to resolve critical vulnerability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5.6
+      - image: cimg/ruby:2.5.6
     steps:
       - checkout
       - run:

--- a/.github/workflows/codeql-scheduled.yml
+++ b/.github/workflows/codeql-scheduled.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5 # The version of Ruby to use
-        bundler: 1.17.3
+        bundler: 2.0.0
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       #env: 
       #  BUNDLE_GEMFILE: ./path/to/Gemfile # Change this to the path to your Gemfile if not in root

--- a/.github/workflows/codeql-scheduled.yml
+++ b/.github/workflows/codeql-scheduled.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5 # The version of Ruby to use
-        bundler: 2.0.0
+        bundler: 2.4.22
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       #env: 
       #  BUNDLE_GEMFILE: ./path/to/Gemfile # Change this to the path to your Gemfile if not in root

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    ravelin (0.1.46)
+      faraday (~> 0.15)
+      faraday_middleware (~> 0.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
+    faraday (0.17.6)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    hashdiff (1.0.1)
+    multipart-post (2.2.3)
+    public_suffix (4.0.7)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.4.22)
+  public_suffix (~> 4.0)
+  rake (~> 13.0)
+  ravelin!
+  rspec (~> 3.0)
+  webmock (~> 3.18)
+
+BUNDLED WITH
+   2.4.22

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.17.3'
+  spec.add_development_dependency 'bundler', '~> 2.0.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.18'

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0.0'
+  spec.add_development_dependency 'bundler', '~> 2.4.22'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.18'


### PR DESCRIPTION
PR raised to address a critical security vulnerability: https://github.com/deliveroo/ravelin-ruby/security/dependabot/5

Also, this PR has been raised to ensure this repository is not archived [[see Slack conversation](https://deliveroo.slack.com/archives/C0494K9E52T/p1710934387486479)].