### PR TITLE
TRST-XXX: Dummy change to fix documentation and ensure repo isn't archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ git commits and tags, and push the `.gem` file to
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-https://github.com/deliveroo/ravelin. This project is intended to be a safe,
+https://github.com/deliveroo/ravelin-ruby. This project is intended to be a safe,
 welcoming space for collaboration, and contributors are expected to adhere to
 the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 


### PR DESCRIPTION
Context around the repo being archived: [Slack Link](https://deliveroo.slack.com/archives/C0494K9E52T/p1710934387486479)