### PR TITLE
TRST-1837: Ravelin client to handle extra headers for post request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.47
+
+Added support for passing optional request headers to ravelin client and ravelin proxy. 
+
 # 0.1.46
 
 Fixed multiple payment methods serialization [#89](https://github.com/deliveroo/ravelin-ruby/pull/85)

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -70,7 +70,7 @@ module Ravelin
 
     def post(url, payload, headers = {})
       response = @connection.post(url, payload.to_json) do |request|
-        headers.each { |key, value|
+        headers&.each { |key, value|
           request.headers[key] =value
         }
       end

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -71,7 +71,7 @@ module Ravelin
     def post(url, payload, headers = {})
       response = @connection.post(url, payload.to_json) do |request|
         headers&.each { |key, value|
-          request.headers[key] =value
+          request.headers[key] = value
         }
       end
 

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -27,11 +27,12 @@ module Ravelin
 
     def send_event(**args)
       score = args.delete(:score)
+      headers = args.delete(:headers)
       event = Event.new(**args)
 
       score_param = score ? "?score=true" : nil
 
-      post("#{@url_prefix}/v#{@api_version}/#{event.name}#{score_param}", event.serializable_hash)
+      post("#{@url_prefix}/v#{@api_version}/#{event.name}#{score_param}", event.serializable_hash, headers)
     end
 
     def send_backfill_event(**args)
@@ -67,8 +68,12 @@ module Ravelin
 
     private
 
-    def post(url, payload)
-      response = @connection.post(url, payload.to_json)
+    def post(url, payload, headers = {})
+      response = @connection.post(url, payload.to_json) do |request|
+        headers.each { |key, value|
+          request.headers[key] =value
+        }
+      end
 
       if response.success?
         Response.new(response)

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = '0.1.46'
+  VERSION = '0.1.47'
 end

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.17.3'
+  spec.add_development_dependency 'bundler', '~> 2.4.19'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.18'

--- a/ravelin.gemspec
+++ b/ravelin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.4.19'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.18'

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -38,29 +38,58 @@ describe Ravelin::Client do
       )
     end
 
-    it 'calls #post with Event payload' do
-      allow(Ravelin::Event).to receive(:new) { event }
+    context "without additional headers" do 
+      let(:headers) {{ 'H1': '123' }}
+      it 'calls #post with Event payload' do
+        allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' })
+        expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' }, headers)
 
-      client.send_event
-    end
+        client.send_event(headers: headers)
+      end
 
-    it 'calls #post with Event payload and score: true' do
-      allow(Ravelin::Event).to receive(:new) { event }
+      it 'calls #post with Event payload and score: true' do
+        allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/v2/foobar?score=true", { id: 'ch-123' })
+        expect(client).to receive(:post).with("/v2/foobar?score=true", { id: 'ch-123' }, headers)
 
-      client.send_event(score: true)
-    end
+        client.send_event(score: true, headers: headers)
+      end
 
-    it 'calls #post with Event payload and score: false' do
-      allow(Ravelin::Event).to receive(:new) { event }
+      it 'calls #post with Event payload and score: false' do
+        allow(Ravelin::Event).to receive(:new) { event }
 
-      expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' })
+        expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' }, headers)
 
-      client.send_event(score: false)
-    end
+        client.send_event(score: false, headers: headers)
+      end
+    end 
+
+    context "wit additional headers" do 
+        it 'calls #post with Event payload' do
+        allow(Ravelin::Event).to receive(:new) { event }
+
+        expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' }, nil)
+
+        client.send_event
+      end
+
+      it 'calls #post with Event payload and score: true' do
+        allow(Ravelin::Event).to receive(:new) { event }
+
+        expect(client).to receive(:post).with("/v2/foobar?score=true", { id: 'ch-123' }, nil)
+
+        client.send_event(score: true)
+      end
+
+      it 'calls #post with Event payload and score: false' do
+        allow(Ravelin::Event).to receive(:new) { event }
+
+        expect(client).to receive(:post).with("/v2/foobar", { id: 'ch-123' }, nil)
+
+        client.send_event(score: false)
+      end
+    end 
   end
 
   describe '#send_backfill_event' do
@@ -177,6 +206,21 @@ describe Ravelin::Client do
         )
 
       client.send_event
+
+      expect(stub).to have_been_requested
+    end
+
+    it "calls Ravelin with correct extra headers and body" do 
+      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping').
+        with(
+          headers: { 'Authorization' => 'token abc', 'H2': '23434'},
+          body: { name: 'value' }.to_json,
+        ).and_return(
+          headers: { 'Content-Type' => 'application/json' },
+          body: '{}'
+        )
+
+      client.send_event(headers: {'H2': '23434'})
 
       expect(stub).to have_been_requested
     end


### PR DESCRIPTION
This PR with release VERSION = '0.1.47': 
- Adds functionality to Ravelin client to accept extra headers for a request. 

Why: 
The current need for this is to send Comparator-Request-Id header from Orderweb to Cluedo (Ravelin Proxy). 